### PR TITLE
Add broadcast functionality to FFN component

### DIFF
--- a/configs/default/components/models/feed_forward_network.yml
+++ b/configs/default/components/models/feed_forward_network.yml
@@ -15,6 +15,13 @@ dropout_rate: 0
 # If true, output of the last layer will be additionally processed with Log Softmax (LOADED)
 use_logsoftmax: True
 
+# Number of dimensions, where:
+#   - 2 means [Batch size, Input size]
+#   - n means [Batch size, dim 1, ..., dim n-2, Input size]
+# And the FFN is broadcasted over the last (Input Size) Dimension.
+# Also, all the dimensions sizes but the last are conserved, as the FFN is applied over the last dimension.
+dimensions: 2
+
 streams: 
   ####################################################################
   # 2. Keymappings associated with INPUT and OUTPUT streams.


### PR DESCRIPTION
The Fully Connected NN will operate only on the last dimension of the input tensor:
[dim 0, dim 1, ..., dim n-2, input dim] -> [dim 0, dim 1, ..., dim n-2, output dim]

The total number of dimensions has to be explicitly set in the config of the FFN, where 2 is the default value for the case [Batch size, input dim].