### PR TITLE
Processor!

### DIFF
--- a/configs/default/components/publishers/stream_file_exporter.yml
+++ b/configs/default/components/publishers/stream_file_exporter.yml
@@ -1,0 +1,34 @@
+# This file defines the default values for the Stream File Exporter.
+
+####################################################################
+# 1. CONFIGURATION PARAMETERS that will be LOADED by the component.
+####################################################################
+
+# List of names of streams that will be displayed (LOADED)
+# Can be string a single name or or comma separated string with list
+input_streams: ''
+
+# Separator that will be placed between values (LOADED)
+separator: ','
+
+# Name of the file containing output values (LOADED)
+filename: 'outputs.txt'
+
+streams: 
+  ####################################################################
+  # 2. Keymappings associated with INPUT and OUTPUT streams.
+  ####################################################################
+
+globals:
+  ####################################################################
+  # 3. Keymappings of variables that will be RETRIEVED from GLOBALS.
+  ####################################################################
+
+  ####################################################################
+  # 4. Keymappings associated with GLOBAL variables that will be SET.
+  ####################################################################
+
+  ####################################################################
+  # 5. Keymappings associated with statistics that will be ADDED.
+  ####################################################################
+

--- a/configs/vqa_med_2019/default_extend_answers.yml
+++ b/configs/vqa_med_2019/default_extend_answers.yml
@@ -9,12 +9,11 @@ training_answers:
     categories: all
     resize_image: &resize_image [224, 224]
     batch_size: 64
-  # No sampler, process samples in the same order.
   dataloader:
-    shuffle: False
-  # Use four workers for loading images.
-  dataloader:
-    num_workers: 4
+    # No sampler, process samples in the same order.
+    shuffle: false
+    # Use 1 worker, so batches will follow the samples order.
+    num_workers: 1
 
 validation_answers:
   problem:
@@ -23,12 +22,11 @@ validation_answers:
     split: validation
     resize_image: *resize_image     
     batch_size: 64
-  # No sampler, process samples in the same order.
   dataloader:
-    shuffle: False
-  # Use four workers for loading images.
-  dataloader:
-    num_workers: 4
+    # No sampler, process samples in the same order.
+    shuffle: false
+    # Use 1 worker, so batches will follow the samples order.
+    num_workers: 1
 
 
 # Testing parameters:
@@ -39,12 +37,11 @@ test_answers:
     split: test
     resize_image: *resize_image     
     batch_size: 64
-  # No sampler, process samples in the same order.
   dataloader:
-    shuffle: False
-  # Use four workers for loading images.
-  dataloader:
-    num_workers: 4
+    # No sampler, process samples in the same order.
+    shuffle: false
+    # Use 1 worker, so batches will follow the samples order.
+    num_workers: 1
 
 # Add component for exporting answers to files.
 pipeline:
@@ -52,7 +49,8 @@ pipeline:
 #  # Viewers.
   viewer_extended:
     type: StreamViewer
+    sample_number: 0
     priority: 100.4
-    input_streams: indices,image_ids,questions,category_names,predicted_categories
+    input_streams: indices,image_ids,questions,category_names,predicted_categories,answers,tokenized_answers,predicted_answers
 
 #: pipeline

--- a/configs/vqa_med_2019/default_extend_answers.yml
+++ b/configs/vqa_med_2019/default_extend_answers.yml
@@ -1,0 +1,58 @@
+# This config is not a standalone config!
+# It adds new sections (sets) without samplers and components for saving answers that we can use for getting final answers.
+
+training_answers:
+  problem:
+    type: &p_type VQAMED2019
+    data_folder: &data_folder ~/data/vqa-med
+    split: training
+    categories: all
+    resize_image: &resize_image [224, 224]
+    batch_size: 64
+  # No sampler, process samples in the same order.
+  dataloader:
+    shuffle: False
+  # Use four workers for loading images.
+  dataloader:
+    num_workers: 4
+
+validation_answers:
+  problem:
+    type: *p_type
+    data_folder: *data_folder
+    split: validation
+    resize_image: *resize_image     
+    batch_size: 64
+  # No sampler, process samples in the same order.
+  dataloader:
+    shuffle: False
+  # Use four workers for loading images.
+  dataloader:
+    num_workers: 4
+
+
+# Testing parameters:
+test_answers:
+  problem:
+    type: *p_type 
+    data_folder: *data_folder
+    split: test
+    resize_image: *resize_image     
+    batch_size: 64
+  # No sampler, process samples in the same order.
+  dataloader:
+    shuffle: False
+  # Use four workers for loading images.
+  dataloader:
+    num_workers: 4
+
+# Add component for exporting answers to files.
+pipeline:
+  disable: viewer
+#  # Viewers.
+  viewer_extended:
+    type: StreamViewer
+    priority: 100.4
+    input_streams: indices,image_ids,questions,category_names,predicted_categories
+
+#: pipeline

--- a/configs/vqa_med_2019/default_extend_answers.yml
+++ b/configs/vqa_med_2019/default_extend_answers.yml
@@ -48,9 +48,15 @@ pipeline:
   disable: viewer
 #  # Viewers.
   viewer_extended:
+    priority: 100.4
     type: StreamViewer
     sample_number: 0
-    priority: 100.4
+    input_streams: indices,image_ids,questions,category_names,predicted_categories,answers,tokenized_answers,predicted_answers
+
+  exporter:
+    priority: 100.5
+    type: StreamFileExporter
+    separator: '|'
     input_streams: indices,image_ids,questions,category_names,predicted_categories,answers,tokenized_answers,predicted_answers
 
 #: pipeline

--- a/configs/vqa_med_2019/default_vqa_med_2019.yml
+++ b/configs/vqa_med_2019/default_vqa_med_2019.yml
@@ -42,14 +42,3 @@ validation:
   # Use four workers for loading images.
   dataloader:
     num_workers: 4
-
-
-# Testing parameters:
-testing:
-  problem:
-    type: *p_type 
-    data_folder: *data_folder
-    split: test
-    resize_image: *resize_image     
-    batch_size: 32
-

--- a/configs/vqa_med_2019/question_categorization/default_question_categorization.yml
+++ b/configs/vqa_med_2019/question_categorization/default_question_categorization.yml
@@ -10,6 +10,15 @@ training:
   terminal_conditions:
     loss_stop: 1.0e-3
 
+validation:
+  problem:
+    categories: all
+
+testing:
+  problem:
+    categories: all
+
+
 pipeline:
 
   # Predictions decoder.

--- a/configs/vqa_med_2019/question_categorization/default_question_categorization.yml
+++ b/configs/vqa_med_2019/question_categorization/default_question_categorization.yml
@@ -2,12 +2,11 @@
 default_configs: vqa_med_2019/default_vqa_med_2019.yml
 
 training:
+  problem:
     categories: all
     export_sample_weights: ~/data/vqa-med/answers.all.weights.csv
   sampler:
     weights: ~/data/vqa-med/answers.all.weights.csv
-
-  # settings parameters
   terminal_conditions:
     loss_stop: 1.0e-3
 

--- a/configs/vqa_med_2019/question_categorization/default_question_categorization.yml
+++ b/configs/vqa_med_2019/question_categorization/default_question_categorization.yml
@@ -14,10 +14,6 @@ validation:
   problem:
     categories: all
 
-testing:
-  problem:
-    categories: all
-
 
 pipeline:
 

--- a/ptp/components/problems/image_text_to_class/vqa_med_2019.py
+++ b/ptp/components/problems/image_text_to_class/vqa_med_2019.py
@@ -650,7 +650,6 @@ class VQAMED2019(Problem):
         :return: DataDict({'indices', 'images', 'images_ids','questions', 'answers', 'category_ids', 'image_sizes'})
 
         """
-        print([sample[self.key_indices] for sample in batch])
         # Collate indices.
         data_dict = self.create_data_dict([sample[self.key_indices] for sample in batch])
 

--- a/ptp/components/problems/image_text_to_class/vqa_med_2019.py
+++ b/ptp/components/problems/image_text_to_class/vqa_med_2019.py
@@ -650,6 +650,7 @@ class VQAMED2019(Problem):
         :return: DataDict({'indices', 'images', 'images_ids','questions', 'answers', 'category_ids', 'image_sizes'})
 
         """
+        print([sample[self.key_indices] for sample in batch])
         # Collate indices.
         data_dict = self.create_data_dict([sample[self.key_indices] for sample in batch])
 

--- a/ptp/components/publishers/__init__.py
+++ b/ptp/components/publishers/__init__.py
@@ -3,6 +3,7 @@ from .batch_size_statistics import BatchSizeStatistics
 from .bleu_statistics import BLEUStatistics
 from .global_variable_publisher import GlobalVariablePublisher
 from .precision_recall_statistics import PrecisionRecallStatistics
+from .stream_file_exporter import StreamFileExporter
 
 __all__ = [
     'AccuracyStatistics',
@@ -10,4 +11,5 @@ __all__ = [
     'BLEUStatistics',
     'GlobalVariablePublisher',
     'PrecisionRecallStatistics',
+    'StreamFileExporter',
     ]

--- a/ptp/components/viewers/stream_viewer.py
+++ b/ptp/components/viewers/stream_viewer.py
@@ -95,9 +95,15 @@ class StreamViewer(Component):
                 sample_number = self.sample_number
 
             # Generate displayed string.
+            absent_streams = []
             disp_str = "Showing selected streams for sample {}:\n".format(sample_number)
             for stream_key in self.input_stream_keys:
                 if stream_key in data_dict.keys():
                     disp_str += " '{}': {}\n".format(stream_key, data_dict[stream_key][sample_number])
+                else:
+                    absent_streams.append(stream_key)
 
+            # Log values and inform about missing streams.
             self.logger.info(disp_str)
+            if len(absent_streams) > 0:
+                self.logger.warning("Coud not display the following (absent) streams: {}".format(absent_streams))

--- a/ptp/configuration/config_parsing.py
+++ b/ptp/configuration/config_parsing.py
@@ -122,7 +122,7 @@ def load_class_default_config_file(class_type):
     module = class_type.__module__.replace(".","/")
     rel_path = module[module.find("ptp")+4:]
     # Build the abs path to the default config file of a given component.
-    abs_default_config = AppState().absolute_config_path + "default/" + rel_path + ".yml"
+    abs_default_config = os.path.join(AppState().absolute_config_path, "default", rel_path) + ".yml"
 
     # Check if file exists.
     if not os.path.isfile(abs_default_config):
@@ -171,29 +171,28 @@ def recurrent_config_parse(configs: str, configs_parsed: list, abs_config_path: 
 
         # Get config.
         config = configs_to_parse.pop(0)
-        abs_config = abs_config_path + config
 
         # Skip empty names (after lose comas).
         if config == '':
             continue
-        print("Info: Parsing the {} configuration file".format(abs_config))
+        print("Info: Parsing the {} configuration file".format(config))
 
         # Check if it was already loaded.
         if config in configs_parsed:
-            print('Warning: Configuration file {} already parsed - skipping'.format(abs_config))
+            print('Warning: Configuration file {} already parsed - skipping'.format(config))
             continue
 
         # Check if file exists.
-        if not os.path.isfile(abs_config):
-            print('Error: Configuration file {} does not exist'.format(abs_config))
+        if not os.path.isfile(config):
+            print('Error: Configuration file {} does not exist'.format(config))
             exit(-1)
 
         try:
             # Open file and get parameter dictionary.
-            with open(abs_config, 'r') as stream:
+            with open(config, 'r') as stream:
                 param_dict = yaml.safe_load(stream)
         except yaml.YAMLError as e:
-            print("Error: Couldn't properly parse the {} configuration file".format(abs_config))
+            print("Error: Couldn't properly parse the {} configuration file".format(config))
             print('yaml.YAMLERROR:', e)
             exit(-1)
 
@@ -202,29 +201,28 @@ def recurrent_config_parse(configs: str, configs_parsed: list, abs_config_path: 
 
         # Check if there are any default configs to load.
         if 'default_configs' in param_dict:
-            # If there are - recursion!
-            configs_parsed = recurrent_config_parse(
-                param_dict['default_configs'], configs_parsed, abs_config_path)
+            default_configs_to_parse = param_dict['default_configs'].replace(" ", "").split(',')
+            # If there are - expand them to absolute paths.
+            abs_default_configs_to_parse = [os.path.join(abs_config_path,config) for config in default_configs_to_parse]
+            # Recursion!
+            configs_parsed = recurrent_config_parse(','.join(abs_default_configs_to_parse), configs_parsed, abs_config_path)
 
     # Done, return list of loaded configs.
     return configs_parsed
 
 
-def reverse_order_config_load(config_interface_obj, configs_to_load, abs_config_path):
+def reverse_order_config_load(config_interface_obj, configs_to_load):
     """
     Loads configuration files in reversed order.
 
     :param config_interface_obj: Configuration interface object.
 
-    :param configs_to_load: list of configuration files to load (relative to config directory)
-
-    :param abs_config_path: Absolute path to config directory.
-
+    :param configs_to_load: list of configuration files to load (with absolute paths)
     """
     for config in reversed(configs_to_load):
         # Load config from YAML file.
-        config_interface_obj.add_config_params_from_yaml(abs_config_path + config)
-        print('Info: Loaded configuration from file {}'.format(abs_config_path + config))
+        config_interface_obj.add_config_params_from_yaml(config)
+        print('Info: Loaded configuration from file {}'.format(config))
 
 
 def get_value_list_from_dictionary(key, parameter_dict, accepted_values = []):

--- a/ptp/configuration/config_parsing.py
+++ b/ptp/configuration/config_parsing.py
@@ -146,14 +146,14 @@ def load_class_default_config_file(class_type):
         exit(-2)
 
 
-def recurrent_config_parse(configs: str, configs_parsed: list, abs_config_path: str):
+def recurrent_config_parse(configs_to_parse: list, configs_parsed: list, abs_config_path: str):
     """
     Parses names of configuration files in a recursive manner, i.e. \
     by looking for ``default_config`` sections and trying to load and parse those \
     files one by one.
 
-    :param configs: String containing names of configuration files (with paths), separated by comas.
-    :type configs: str
+    :param configs_to_parse: List containing names of configuration files (with paths).
+    :type configs_to_parse: list
 
     :param configs_parsed: Configurations that were already parsed (so we won't parse them many times).
     :type configs_parsed: list
@@ -163,9 +163,6 @@ def recurrent_config_parse(configs: str, configs_parsed: list, abs_config_path: 
     :return: list of parsed configuration files.
 
     """
-    # Split and remove spaces.
-    configs_to_parse = configs.replace(" ", "").split(',')
-
     # Terminal condition.
     while len(configs_to_parse) > 0:
 
@@ -205,7 +202,7 @@ def recurrent_config_parse(configs: str, configs_parsed: list, abs_config_path: 
             # If there are - expand them to absolute paths.
             abs_default_configs_to_parse = [os.path.join(abs_config_path,config) for config in default_configs_to_parse]
             # Recursion!
-            configs_parsed = recurrent_config_parse(','.join(abs_default_configs_to_parse), configs_parsed, abs_config_path)
+            configs_parsed = recurrent_config_parse(abs_default_configs_to_parse, configs_parsed, abs_config_path)
 
     # Done, return list of loaded configs.
     return configs_parsed

--- a/ptp/utils/app_state.py
+++ b/ptp/utils/app_state.py
@@ -19,6 +19,8 @@ __author__ = "Alexis Asseman, Tomasz Kornuta"
 
 import torch
 
+from os import path
+
 from ptp.utils.singleton import SingletonMetaClass
 
 
@@ -52,6 +54,11 @@ class AppState(metaclass=SingletonMetaClass):
 
         # Field storing global variables.
         self.__globals = dict()
+
+        # Get absolute path to configs from "~/./ptp/configs".
+        ptp_path = path.expanduser("~/.ptp/")
+        with open(path.join(ptp_path, "config.txt")) as file:
+            self.absolute_config_path = file.readline()
 
         # Initialize logger logfile (as empty for now).
         self.log_file = None

--- a/ptp/utils/app_state.py
+++ b/ptp/utils/app_state.py
@@ -63,6 +63,8 @@ class AppState(metaclass=SingletonMetaClass):
         # Initialize logger logfile (as empty for now).
         self.log_file = None
         self.logger = None
+        # Set default path to current dir.
+        self.log_dir = path.expanduser(".")
 
         # Set CPU types as default.
         self.set_cpu_types()

--- a/ptp/workers/__init__.py
+++ b/ptp/workers/__init__.py
@@ -2,12 +2,12 @@ from .worker import Worker
 from .trainer import Trainer
 #from .offline_trainer import OfflineTrainer
 from .online_trainer import OnlineTrainer
-#from .tester import Tester
+from .processor import Processor
 
 __all__ = [
     'Worker',
     'Trainer',
     #'OfflineTrainer',
     'OnlineTrainer',
-    #'Tester'
+    'Processor'
     ]

--- a/ptp/workers/online_trainer.py
+++ b/ptp/workers/online_trainer.py
@@ -34,9 +34,8 @@ class OnlineTrainer(Trainer):
         it makes less sense for problems which have a very large, almost infinite, dataset (like algorithmic \
         tasks, which generate random data on-the-fly). \
          
-        This is why this OnlineTrainer was implemented. Instead of looping on epochs, it iterates directly on \
-        episodes (we call an iteration on a single batch an episode).
-
+        This is why this OnlineTrainer was implemented. Despite the fact it has the notion of epoch, it is more \
+        flexible and operates on episodes (we call an iteration on a single batch an episode). \
 
     """
 

--- a/ptp/workers/online_trainer.py
+++ b/ptp/workers/online_trainer.py
@@ -107,7 +107,7 @@ class OnlineTrainer(Trainer):
         # Export and log configuration, optionally asking the user for confirmation.
         config_parsing.display_parsing_results(self.logger, self.app_state.args, self.unparsed)
         config_parsing.display_globals(self.logger, self.app_state.globalitems())
-        config_parsing.export_experiment_configuration_to_yml(self.logger, self.log_dir, "training_configuration.yml", self.config, self.app_state.args.confirm)
+        config_parsing.export_experiment_configuration_to_yml(self.logger, self.app_state.log_dir, "training_configuration.yml", self.config, self.app_state.args.confirm)
 
     def run_experiment(self):
         """
@@ -345,7 +345,7 @@ class OnlineTrainer(Trainer):
             # Finalize statistics collection.
             self.finalize_statistics_collection()
             self.finalize_tensorboard()
-            self.logger.info("Experiment logged to: {}".format(self.log_dir))
+            self.logger.info("Experiment logged to: {}".format(self.app_state.log_dir))
 
 
 def main():

--- a/ptp/workers/online_trainer.py
+++ b/ptp/workers/online_trainer.py
@@ -107,7 +107,7 @@ class OnlineTrainer(Trainer):
         # Export and log configuration, optionally asking the user for confirmation.
         config_parsing.display_parsing_results(self.logger, self.app_state.args, self.unparsed)
         config_parsing.display_globals(self.logger, self.app_state.globalitems())
-        config_parsing.export_experiment_configuration_to_yml(self.logger, self.log_dir, "training_configuration.yaml", self.config, self.app_state.args.confirm)
+        config_parsing.export_experiment_configuration_to_yml(self.logger, self.log_dir, "training_configuration.yml", self.config, self.app_state.args.confirm)
 
     def run_experiment(self):
         """

--- a/ptp/workers/trainer.py
+++ b/ptp/workers/trainer.py
@@ -131,8 +131,6 @@ class Trainer(Worker):
             print('Please pass configuration file(s) as --c parameter')
             exit(-2)
 
-        # Get configuration file(s) from command args.
-        root_config = self.app_state.args.config
         # Split and make them absolute.
         root_configs = self.app_state.args.config.replace(" ", "").split(',')
         # If there are - expand them to absolute paths.

--- a/ptp/workers/trainer.py
+++ b/ptp/workers/trainer.py
@@ -137,18 +137,11 @@ class Trainer(Worker):
             print('Error: Configuration file {} does not exist'.format(root_config))
             exit(-3)
         
-        # Extract absolute path to main ptp 'config' directory.
-        abs_config_path = os.path.abspath(root_config)
-        # Save it in app_state!
-        self.app_state.absolute_config_path = abs_config_path[:abs_config_path.find("configs")+8] 
-        # Get relative path.
-        rel_config_path = abs_config_path[abs_config_path.find("configs")+8:]
-
         # Get the list of configurations which need to be loaded.
-        configs_to_load = config_parse.recurrent_config_parse(rel_config_path, [], self.app_state.absolute_config_path)
+        configs_to_load = config_parse.recurrent_config_parse(root_config, [], self.app_state.absolute_config_path)
 
         # Read the YAML files one by one - but in reverse order -> overwrite the first indicated config(s)
-        config_parse.reverse_order_config_load(self.config, configs_to_load, self.app_state.absolute_config_path)
+        config_parse.reverse_order_config_load(self.config, configs_to_load)
 
         # -> At this point, the Param Registry contains the configuration loaded (and overwritten) from several files.
         # Log the resulting training configuration.

--- a/ptp/workers/trainer.py
+++ b/ptp/workers/trainer.py
@@ -90,7 +90,7 @@ class Trainer(Worker):
 
         - Set up the log directory path:
 
-            >>> os.makedirs(self.log_dir, exist_ok=False)
+            >>> os.makedirs(self.app_state.log_dir, exist_ok=False)
 
         - Add a ``FileHandler`` to the logger:
 
@@ -178,28 +178,28 @@ class Trainer(Worker):
                 time_str = '{0:%Y%m%d_%H%M%S}'.format(datetime.now())
                 if self.app_state.args.savetag != '':
                     time_str = time_str + "_" + self.app_state.args.savetag
-                self.log_dir = os.path.expanduser(self.app_state.args.expdir) + '/' + training_problem_type + '/' + pipeline_name + '/' + time_str + '/'
+                self.app_state.log_dir = os.path.expanduser(self.app_state.args.expdir) + '/' + training_problem_type + '/' + pipeline_name + '/' + time_str + '/'
                 # Lowercase dir.
-                self.log_dir = self.log_dir.lower()
-                os.makedirs(self.log_dir, exist_ok=False)
+                self.app_state.log_dir = self.app_state.log_dir.lower()
+                os.makedirs(self.app_state.log_dir, exist_ok=False)
             except FileExistsError:
                 sleep(1)
             else:
                 break
 
         # Set log dir.
-        self.app_state.log_file = self.log_dir + 'trainer.log'
+        self.app_state.log_file = self.app_state.log_dir + 'trainer.log'
         # Initialize logger in app state.
         self.app_state.logger = logging.initialize_logger("AppState")
         # Add handlers for the logfile to worker logger.
         logging.add_file_handler_to_logger(self.logger)
-        self.logger.info("Logger directory set to: {}".format(self.log_dir ))
+        self.logger.info("Logger directory set to: {}".format(self.app_state.log_dir))
 
         # Set cpu/gpu types.
         self.app_state.set_types()
 
         # Models dir.
-        self.checkpoint_dir = self.log_dir + 'checkpoints/'
+        self.checkpoint_dir = self.app_state.log_dir + 'checkpoints/'
         os.makedirs(self.checkpoint_dir, exist_ok=False)
 
         # Set random seeds in the training section.
@@ -380,7 +380,7 @@ class Trainer(Worker):
         self.training.problem.add_statistics(self.training_stat_col)
         self.pipeline.add_statistics(self.training_stat_col)
         # Create the csv file to store the training statistics.
-        self.training_batch_stats_file = self.training_stat_col.initialize_csv_file(self.log_dir, 'training_statistics.csv')
+        self.training_batch_stats_file = self.training_stat_col.initialize_csv_file(self.app_state.log_dir, 'training_statistics.csv')
 
         # Create statistics aggregator for training.
         self.training_stat_agg = StatisticsAggregator()
@@ -388,7 +388,7 @@ class Trainer(Worker):
         self.training.problem.add_aggregators(self.training_stat_agg)
         self.pipeline.add_aggregators(self.training_stat_agg)
         # Create the csv file to store the training statistic aggregations.
-        self.training_set_stats_file = self.training_stat_agg.initialize_csv_file(self.log_dir, 'training_set_agg_statistics.csv')
+        self.training_set_stats_file = self.training_stat_agg.initialize_csv_file(self.app_state.log_dir, 'training_set_agg_statistics.csv')
 
         # VALIDATION.
         # Create statistics collector for validation.
@@ -397,7 +397,7 @@ class Trainer(Worker):
         self.validation.problem.add_statistics(self.validation_stat_col)
         self.pipeline.add_statistics(self.validation_stat_col)
         # Create the csv file to store the validation statistics.
-        self.validation_batch_stats_file = self.validation_stat_col.initialize_csv_file(self.log_dir, 'validation_statistics.csv')
+        self.validation_batch_stats_file = self.validation_stat_col.initialize_csv_file(self.app_state.log_dir, 'validation_statistics.csv')
 
         # Create statistics aggregator for validation.
         self.validation_stat_agg = StatisticsAggregator()
@@ -405,7 +405,7 @@ class Trainer(Worker):
         self.validation.problem.add_aggregators(self.validation_stat_agg)
         self.pipeline.add_aggregators(self.validation_stat_agg)
         # Create the csv file to store the validation statistic aggregations.
-        self.validation_set_stats_file = self.validation_stat_agg.initialize_csv_file(self.log_dir, 'validation_set_agg_statistics.csv')
+        self.validation_set_stats_file = self.validation_stat_agg.initialize_csv_file(self.app_state.log_dir, 'validation_set_agg_statistics.csv')
 
 
     def finalize_statistics_collection(self):
@@ -428,16 +428,16 @@ class Trainer(Worker):
         # Create TensorBoard outputs - if TensorBoard is supposed to be used.
         if self.app_state.args.tensorboard is not None:
             from tensorboardX import SummaryWriter
-            self.training_batch_writer = SummaryWriter(self.log_dir + '/training')
+            self.training_batch_writer = SummaryWriter(self.app_state.log_dir + '/training')
             self.training_stat_col.initialize_tensorboard(self.training_batch_writer)
 
-            self.training_set_writer = SummaryWriter(self.log_dir + '/training_set_agg')
+            self.training_set_writer = SummaryWriter(self.app_state.log_dir + '/training_set_agg')
             self.training_stat_agg.initialize_tensorboard(self.training_set_writer)
             
-            self.validation_batch_writer = SummaryWriter(self.log_dir + '/validation')
+            self.validation_batch_writer = SummaryWriter(self.app_state.log_dir + '/validation')
             self.validation_stat_col.initialize_tensorboard(self.validation_batch_writer)
 
-            self.validation_set_writer = SummaryWriter(self.log_dir + '/validation_set_agg')
+            self.validation_set_writer = SummaryWriter(self.app_state.log_dir + '/validation_set_agg')
             self.validation_stat_agg.initialize_tensorboard(self.validation_set_writer)
         else:
             self.training_batch_writer = None

--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,7 @@ setup(
     entry_points={  # Optional
          'console_scripts': [
              'ptp-online-trainer=ptp.workers.online_trainer:main',
-             #'ptp-tester=ptp.workers.tester:main',
+             'ptp-processor=ptp.workers.processor:main',
          ]
      },
 

--- a/setup.py
+++ b/setup.py
@@ -11,16 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""A setuptools based setup module.
-
-See:
-https://packaging.python.org/en/latest/distributing.html
-https://github.com/pypa/sampleproject
-"""
 
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
-from os import path
+from os import path,makedirs
 # io.open is needed for projects that support Python 2.7
 # It ensures open() defaults to text mode with universal newlines,
 # and accepts an argument to specify the text encoding
@@ -28,6 +22,16 @@ from os import path
 # from io import open
 
 here = path.abspath(path.dirname(__file__))
+
+# Get path to configs.
+configs_path = path.join(here,"configs/")
+# Export path to config file in ~/.ptp/ folder.
+ptp_path = path.expanduser("~/.ptp/")
+# Make dir.
+makedirs(path.dirname(ptp_path), exist_ok=True)
+# Write path to configs.
+with open(path.join(ptp_path, "config.txt"),"w") as file:
+    file.write(configs_path)
 
 # Get the long description from the README file
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
@@ -61,7 +65,7 @@ setup(
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#summary
-    description='PyTorchPipe: framework for building PyTorch pipelines',
+    description='PyTorchPipe: framework for building multi-modal PyTorch pipelines',
 
     # This is an optional longer description of your project that represents
     # the body of text which users will see when they visit PyPI.
@@ -89,7 +93,7 @@ setup(
     #
     # This field corresponds to the "Home-Page" metadata field:
     # https://packaging.python.org/specifications/core-metadata/#home-page-optional
-    url='https://github.com/tkornut/pytorchpipe/',  # Optional
+    url='https://github.com/IBM/pytorchpipe/',  # Optional
     license='Apache 2.0',
 
     # This should be your name or the name of the organization which owns the
@@ -116,20 +120,12 @@ setup(
         # Indicate who your project is intended for
         'Intended Audience :: Science/Research',
         'Intended Audience :: Developers',
-        # 'Topic :: Software Development :: Build Tools',
 
         # Pick your license as you wish
-        # 'License :: OSI Approved :: MIT License',
-        # 'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'License :: OSI Approved :: Apache Software License',
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        # 'Programming Language :: Python :: 2',
-        # 'Programming Language :: Python :: 2.7',
-        # 'Programming Language :: Python :: 3',
-        # 'Programming Language :: Python :: 3.4',
-        # 'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
 
         'Operating System :: Linux',
@@ -140,7 +136,7 @@ setup(
     # project page. What does your project relate to?
     #
     # Note that this is a string of words separated by whitespace, not a list.
-    keywords='pytorch pipeline component',  # Optional
+    keywords='machine learning neural nets pytorch pipeline component problem model',  # Optional
 
     # You can just specify package directories manually here if your project is
     # simple. Or you can use find_packages().
@@ -216,7 +212,7 @@ setup(
     entry_points={  # Optional
          'console_scripts': [
              'ptp-online-trainer=ptp.workers.online_trainer:main',
-             'ptp-tester=ptp.workers.tester:main',
+             #'ptp-tester=ptp.workers.tester:main',
          ]
      },
 

--- a/tests/pipeline_tests.py
+++ b/tests/pipeline_tests.py
@@ -31,10 +31,6 @@ class TestPipeline(unittest.TestCase):
         # Set required globals.
         app_state = AppState()
         app_state.__setitem__("bow_size", 10, override=True)
-        # Extract absolute path to config.
-        abs_config_path = os.path.realpath(__file__)
-        # Save it in app_state!
-        app_state.absolute_config_path = abs_config_path[:abs_config_path.find("tests")]+"configs/"
  
     def test_create_component_full_type(self):
         """ Tests whether component can be created when using full module name with 'path'. """
@@ -123,5 +119,5 @@ class TestPipeline(unittest.TestCase):
         self.assertEqual(pipe[1].name, 'bow_encoder2')
 
 
-#if __name__ == "__main__":
-#    unittest.main()
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Refactored method that loads default configuration for components (IMPORTANT!)
    * The new approach relies on path saved by setup.py to ~/.ptp/configs
    => As a result, one might run ptp-* in any folder and point configuration file from any other folder as well!
    => Added option to load many configuration files from command line
(WARNING!) After merge, everyone will have to run python setup.py develop/install
- Refactored Processor, enabled option to process any set (section containing problem) from the config file
- Added StreamFileExporter component that exports values of streams to file
- Create default_extend_answer.yml config that we will use as "secondary" config loaded from command line:
    * Config contains three new sections (training_answers,validation_answers,test_answers) that sample items one by one (without shuffling)
    * It also adds component StreamFileExporter that exports all values from all streams to file
(INFO: to be used with ptp-processor only that makes a single pass over the whole set)

Exemplary usage: (loads the pretrained question categorization pipeline and uses it to get answers for test set defined in 'test_answers' section of default_extend_answers.yml)

ptp-processor --load ~/image-clef-2019/experiments/q_categorization/20190416_120801/checkpoints/vqa_med_question_categorization_rnn_ffn_best.pt --c configs/vqa_med_2019/question_categorization/question_categorization_rnn_ffn.yml,configs/vqa_med_2019/default_extend_answers.yml --set test_answers