### PR TITLE
Add support for <EOS> token

### DIFF
--- a/configs/default/components/losses/nll_loss.yml
+++ b/configs/default/components/losses/nll_loss.yml
@@ -37,6 +37,9 @@ globals:
   # 3. Keymappings of variables that will be RETRIEVED from GLOBALS.
   ####################################################################
 
+  # Target value to ignore (masking)
+  ignore_index: ignore_index
+
   ####################################################################
   # 4. Keymappings associated with GLOBAL variables that will be SET.
   ####################################################################

--- a/configs/default/components/models/sentence_embeddings.yml
+++ b/configs/default/components/models/sentence_embeddings.yml
@@ -11,8 +11,14 @@ data_folder: '~/data/'
 source_vocabulary_files: ''
 
 # Additional tokens that will be added to vocabulary (LOADED)
-# This list can be extended, but <PAD> is a special token used ALWAYS for padding shorter sequences.
-additional_tokens: '<PAD>'
+# This list can be extended, but <PAD> and <EOS> are special tokens.
+# <PAD> is ALWAYS used for padding shorter sequences.
+additional_tokens: '<PAD>,<EOS>'
+
+# Enable <EOS> (end of sequence) token.
+eos_token: False
+
+export_pad_mapping_to_globals: False
 
 # File containing word (LOADED)
 word_mappings_file: 'word_mappings.csv'

--- a/configs/default/components/models/sentence_embeddings.yml
+++ b/configs/default/components/models/sentence_embeddings.yml
@@ -18,7 +18,7 @@ additional_tokens: '<PAD>,<EOS>'
 # Enable <EOS> (end of sequence) token.
 eos_token: False
 
-export_pad_mapping_to_globals: False
+export_pad_index_to_globals: False
 
 # File containing word (LOADED)
 word_mappings_file: 'word_mappings.csv'
@@ -74,6 +74,10 @@ globals:
   # It is exported to globals, so other components can use it during
   # their initialization.
   embeddings_size: embeddings_size
+
+  # Index of the <PAD> token
+  # Will be set only if `export_pad_mapping_to_globals == True`
+  pad_index: pad_index
 
   ####################################################################
   # 5. Keymappings associated with statistics that will be ADDED.

--- a/configs/default/components/text/label_indexer.yml
+++ b/configs/default/components/text/label_indexer.yml
@@ -16,6 +16,9 @@ additional_tokens: ''
 # File containing word (LOADED)
 word_mappings_file: 'word_mappings.csv'
 
+# HACK: This key is useless here, but needed by parent class. Should be removed/fixed in the future
+export_pad_index_to_globals: False
+
 # If set, component will always (re)generate the vocabulary (LOADED)
 regenerate: False 
 

--- a/configs/default/components/text/sentence_indexer.yml
+++ b/configs/default/components/text/sentence_indexer.yml
@@ -11,8 +11,14 @@ data_folder: '~/data/'
 source_vocabulary_files: ''
 
 # Additional tokens that will be added to vocabulary (LOADED)
-# This list can be extended, but <PAD> is a special token used ALWAYS for padding shorter sequences.
-additional_tokens: '<PAD>'
+# This list can be extended, but <PAD> and <EOS> are special tokens.
+# <PAD> is ALWAYS used for padding shorter sequences.
+additional_tokens: '<PAD>,<EOS>'
+
+# Enable <EOS> (end of sequence) token.
+eos_token: False
+
+export_pad_mapping_to_globals: False
 
 # File containing word (LOADED)
 word_mappings_file: 'word_mappings.csv'
@@ -67,6 +73,11 @@ globals:
   # Size of the vocabulary (RETRIEVED/SET)
   # This depends on the import/export configuration flags above.
   vocabulary_size: vocabulary_size
+
+
+  # Index of the <PAD> token
+  # Will be set only if `export_pad_mapping_to_globals == True`
+  pad_mapping: pad_mapping
 
   ####################################################################
   # 5. Keymappings associated with statistics that will be ADDED.

--- a/configs/default/components/text/sentence_indexer.yml
+++ b/configs/default/components/text/sentence_indexer.yml
@@ -18,6 +18,7 @@ additional_tokens: '<PAD>,<EOS>'
 # Enable <EOS> (end of sequence) token.
 eos_token: False
 
+# HACK: This key is useless here, but needed by parent class. Should be removed/fixed in the future
 export_pad_index_to_globals: False
 
 # File containing word (LOADED)

--- a/configs/default/components/text/sentence_indexer.yml
+++ b/configs/default/components/text/sentence_indexer.yml
@@ -18,7 +18,7 @@ additional_tokens: '<PAD>,<EOS>'
 # Enable <EOS> (end of sequence) token.
 eos_token: False
 
-export_pad_mapping_to_globals: False
+export_pad_index_to_globals: False
 
 # File containing word (LOADED)
 word_mappings_file: 'word_mappings.csv'
@@ -74,10 +74,9 @@ globals:
   # This depends on the import/export configuration flags above.
   vocabulary_size: vocabulary_size
 
-
   # Index of the <PAD> token
   # Will be set only if `export_pad_mapping_to_globals == True`
-  pad_mapping: pad_mapping
+  pad_index: pad_index
 
   ####################################################################
   # 5. Keymappings associated with statistics that will be ADDED.

--- a/configs/default/components/text/sentence_one_hot_encoder.yml
+++ b/configs/default/components/text/sentence_one_hot_encoder.yml
@@ -16,6 +16,9 @@ additional_tokens: ''
 # File containing word (LOADED)
 word_mappings_file: 'word_mappings.csv'
 
+# HACK: This key is useless here, but needed by parent class. Should be removed/fixed in the future
+export_pad_index_to_globals: False
+
 # If set, component will always (re)generate the vocabulary (LOADED)
 regenerate: False 
 

--- a/configs/default/components/text/word_decoder.yml
+++ b/configs/default/components/text/word_decoder.yml
@@ -13,6 +13,9 @@ source_vocabulary_files: ''
 # Additional tokens that will be added to vocabulary (LOADED)
 additional_tokens: ''
 
+# HACK: This key is useless here, but needed by parent class. Should be removed/fixed in the future
+export_pad_index_to_globals: False
+
 # File containing word (LOADED)
 word_mappings_file: 'word_mappings.csv'
 

--- a/configs/vqa_med_2019/c4_classification/c4_enc_attndec.yml
+++ b/configs/vqa_med_2019/c4_classification/c4_enc_attndec.yml
@@ -61,6 +61,7 @@ pipeline:
     globals:
       vocabulary_size: ans_vocabulary_size
       word_mappings: ans_word_mappings
+      pad_index: ans_pad_index
 
   # Single layer GRU Encoder
   encoder:
@@ -121,6 +122,8 @@ pipeline:
     streams:
       targets: indexed_answers
       loss: loss
+    globals:
+      ignore_index: ans_pad_index
 
   # Prediction decoding.
   prediction_decoder:

--- a/ptp/components/losses/nll_loss.py
+++ b/ptp/components/losses/nll_loss.py
@@ -45,8 +45,15 @@ class NLLLoss(Loss):
         # Get number of targets dimensions.
         self.num_targets_dims = self.config["num_targets_dims"]
 
+        # Get the optional ignore_index. -100 is the default value in PyTorch
+        self.ignore_index = -100
+        try:
+            self.ignore_index = self.globals["ignore_index"]
+        except KeyError:
+            pass
+
         # Set loss.
-        self.loss_function = nn.NLLLoss()
+        self.loss_function = nn.NLLLoss(ignore_index=self.ignore_index)
 
 
     def input_data_definitions(self):

--- a/ptp/components/mixins/word_mappings.py
+++ b/ptp/components/mixins/word_mappings.py
@@ -72,6 +72,9 @@ class WordMappings(object):
             if word != '' and word not in self.word_to_ix:
                 self.word_to_ix[word] = len(self.word_to_ix)
 
+        if self.config["export_pad_mapping_to_globals"]:
+            self.globals["pad_mapping"] = self.word_to_ix['<PAD>']
+
         self.logger.info("Initialized word mappings with vocabulary of size {}".format(len(self.word_to_ix)))
 
         # Check if we want to export word mappings to globals.

--- a/ptp/components/mixins/word_mappings.py
+++ b/ptp/components/mixins/word_mappings.py
@@ -72,8 +72,8 @@ class WordMappings(object):
             if word != '' and word not in self.word_to_ix:
                 self.word_to_ix[word] = len(self.word_to_ix)
 
-        if self.config["export_pad_mapping_to_globals"]:
-            self.globals["pad_mapping"] = self.word_to_ix['<PAD>']
+        if self.config["export_pad_index_to_globals"]:
+            self.globals["pad_index"] = self.word_to_ix['<PAD>']
 
         self.logger.info("Initialized word mappings with vocabulary of size {}".format(len(self.word_to_ix)))
 

--- a/ptp/components/text/sentence_indexer.py
+++ b/ptp/components/text/sentence_indexer.py
@@ -54,6 +54,9 @@ class SentenceIndexer(Component, WordMappings):
         # Force padding to a fixed length
         self.fixed_padding = self.config['fixed_padding']
 
+        # Wether to add <EOS> at the end of sequence
+        self.enable_eos_token = self.config['eos_token']
+
         if self.mode_reverse:
             # We will need reverse (index:word) mapping.
             self.ix_to_word = dict((v,k) for k,v in self.word_to_ix.items())
@@ -133,6 +136,7 @@ class SentenceIndexer(Component, WordMappings):
 
         # Get index of padding.
         pad_index = self.word_to_ix['<PAD>']
+        eos_index = self.word_to_ix['<EOS>'] if self.enable_eos_token else None
 
         outputs_list = []
         # Process sentences 1 by 1.
@@ -150,7 +154,7 @@ class SentenceIndexer(Component, WordMappings):
             # Apply fixed padding to all sequences if requested
             # Otherwise let torch.nn.utils.rnn.pad_sequence handle it and choose a dynamic padding
             if self.fixed_padding > 0:
-                pad_trunc_list(output_sample, self.fixed_padding, padding_value=pad_index)
+                pad_trunc_list(output_sample, self.fixed_padding, padding_value=pad_index, eos_value=eos_index)
 
             outputs_list.append(self.app_state.LongTensor(output_sample))
 

--- a/ptp/components/utils/word_mappings.py
+++ b/ptp/components/utils/word_mappings.py
@@ -133,7 +133,7 @@ def save_word_mappings_to_csv_file(logger, folder, filename, word_to_ix, fieldna
 
     logger.info("Saved mappings of size {} to file '{}'".format(len(word_to_ix), file_path))
 
-def pad_trunc_list(l: list, length: int, padding_value = 0):
+def pad_trunc_list(l: list, length: int, padding_value = 0, eos_value = None):
     """
     Will apply padding / clipping to list to meet requested length.
     Works on the list in-place.
@@ -146,7 +146,13 @@ def pad_trunc_list(l: list, length: int, padding_value = 0):
 
     :return: None
     """
+    
     if len(l) < length:
+        if eos_value is not None:
+            l.append(eos_value)
         l.extend([padding_value]*(length-len(l)))
+        
     elif len(l) > length:
         del l[length:]
+        if eos_value is not None:
+            l[length-1] = eos_value


### PR DESCRIPTION
In sentence indexer:
- Add optional `<EOS>` token to sentence.
- Option to export `<EOS>` index to globals.
In `NLLLoss`:
- Option to import an `ignore_index` from globals, to use as masking for the loss

This also has the added benefit of giving a more meaningful loss value that can be used as an accuracy metric.