### PR TITLE
Added dataparallel cmd arg, dataparallel mode to torchvision wrapper

### DIFF
--- a/ptp/components/models/torch_vision_wrapper.py
+++ b/ptp/components/models/torch_vision_wrapper.py
@@ -138,6 +138,9 @@ class TorchVisionWrapper(Model):
                 self.output_size = self.globals["output_size"]
                 self.model.fc = torch.nn.Linear(2048, self.output_size)
 
+        if self.app_state.use_dataparallel and self.app_state.use_gpu:
+            self.model = torch.nn.DataParallel(self.model)
+
 
     def input_data_definitions(self):
         """

--- a/ptp/utils/app_state.py
+++ b/ptp/utils/app_state.py
@@ -69,6 +69,7 @@ class AppState(metaclass=SingletonMetaClass):
         # Set CPU types as default.
         self.set_cpu_types()
         self.use_gpu = False
+        self.use_dataparallel = False
 
         # Reset global counters.
         self.epoch = None # Processor is not using the notion of epoch.
@@ -85,6 +86,8 @@ class AppState(metaclass=SingletonMetaClass):
             self.logger.info('Running computations on GPU using CUDA')
             self.set_gpu_types()
             self.use_gpu = True
+            if self.args.use_dataparallel:
+                self.use_dataparallel = True
         elif self.args.use_gpu:
             self.logger.warning('GPU utilization is demanded but there are no available GPU devices! Using CPUs instead')
         else:

--- a/ptp/workers/worker.py
+++ b/ptp/workers/worker.py
@@ -104,6 +104,13 @@ class Worker(object):
                     'in the system. (Default: False)')
 
             self.parser.add_argument(
+                '--dataparallel',
+                dest='use_dataparallel',
+                action='store_true',
+                help='Compatible models will be converted to torch.nn.DataParallel to use all the '
+                    'available GPUs in parallel. To be used with the --gpu option. (Default: False)')
+
+            self.parser.add_argument(
                 '--expdir',
                 dest='expdir',
                 type=str,


### PR DESCRIPTION
Added `--dataparallel` argument to worker.py, to use in conjunction with `--gpu`.
Note that only the `TorchVisionWrapper` is compatible for now, and will be the only model in your pipeline to be parallelized.
Note also that you might have to use more workers in the data generators to be able to feed the multiple GPUs in a timely manner.
Finally, I'll remind you that DataParallel will try to use all the visible GPUs. So alter the `CUDA_VISIBLE_DEVICES` env variable before launching ptp, or use `cuda-gpupick` which will do it for you.

PS: There was probably a better/cleaner way to implement this, but this what I came up with considering our limited time.