### PR TITLE
Implemented Self Attention for Question Encoding

### DIFF
--- a/configs/default/components/models/recurrent_neural_network.yml
+++ b/configs/default/components/models/recurrent_neural_network.yml
@@ -18,9 +18,9 @@ hidden_size: 100
 input_mode: Dense
 
 # Prediction mode (LOADED)
-# Options: 
+# Options:
 #   * Dense (passes every activation through output layer) |
-#   * Last (passes only the last activation though output layer) |
+#   * Last (passes only the last activation through output layer) |
 #   * None (all outputs are discarded)
 prediction_mode: Dense
 
@@ -55,7 +55,7 @@ output_last_state: False
 # If true, output of the last layer will be additionally processed with Log Softmax (LOADED)
 use_logsoftmax: True
 
-streams: 
+streams:
   ####################################################################
   # 2. Keymappings associated with INPUT and OUTPUT streams.
   ####################################################################
@@ -92,4 +92,3 @@ globals:
   ####################################################################
   # 5. Keymappings associated with statistics that will be ADDED.
   ####################################################################
-

--- a/configs/default/components/models/vqa/self_attention.yml
+++ b/configs/default/components/models/vqa/self_attention.yml
@@ -1,0 +1,46 @@
+# This file defines the default values for the Self_Attention model.
+
+####################################################################
+# 1. CONFIGURATION PARAMETERS that will be LOADED by the component.
+####################################################################
+
+# Dropout rate (LOADED)
+# Default: 0 (means that it is turned off)
+dropout_rate: 0
+
+# Size of the latent space (LOADED)
+latent_size: 256
+
+# Number of attention heads (LOADED)
+num_attention_heads: 4
+
+
+streams:
+  ####################################################################
+  # 2. Keymappings associated with INPUT and OUTPUT streams.
+  ####################################################################
+
+  # Stream containing batch of encoded questions (INPUT)
+  question_encodings: question_encodings
+
+  # Stream containing outputs (OUTPUT)
+  outputs: outputs
+
+globals:
+  ####################################################################
+  # 3. Keymappings of variables that will be RETRIEVED from GLOBALS.
+  ####################################################################
+
+  # Size of the question encodings input (RETRIEVED)
+  question_encoding_size: question_encoding_size
+
+  # Size of the output (RETRIEVED)
+  output_size: output_size
+
+  ####################################################################
+  # 4. Keymappings associated with GLOBAL variables that will be SET.
+  ####################################################################
+
+  ####################################################################
+  # 5. Keymappings associated with statistics that will be ADDED.
+  ####################################################################

--- a/configs/vqa_med_2019/c2_classification/c2_class_lstm_selfattn.yml
+++ b/configs/vqa_med_2019/c2_classification/c2_class_lstm_selfattn.yml
@@ -1,0 +1,90 @@
+# Load config defining problems for training, validation and testing.
+default_configs: vqa_med_2019/c2_classification/default_c2_classification.yml
+
+training:
+  problem:
+    batch_size: 48
+    # Appy all preprocessing/data augmentations.
+    question_preprocessing: lowercase,remove_punctuation,tokenize
+    streams:
+      # Problem is returning tokenized questions.
+      questions: tokenized_questions
+
+validation:
+  problem:
+    batch_size: 48
+    # Appy all preprocessing/data augmentations.
+    question_preprocessing: lowercase,remove_punctuation,tokenize
+    streams:
+      # Problem is returning tokenized questions.
+      questions: tokenized_questions
+
+
+pipeline:
+
+  global_publisher:
+    priority: 0
+    type: GlobalVariablePublisher
+    # Add input_size to globals.
+    keys: [question_encoder_output_size, attention_activation_size]
+    values: [100, 400]
+
+  ################# PIPE 0: question #################
+
+  # Model 1: Embeddings
+  question_embeddings:
+    priority: 1.2
+    type: SentenceEmbeddings
+    embeddings_size: 100
+    pretrained_embeddings_file: glove.6B.100d.txt
+    data_folder: ~/data/vqa-med
+    word_mappings_file: questions.all.word.mappings.csv
+    streams:
+      inputs: tokenized_questions
+      outputs: embedded_questions
+
+  # Model 2: RNN
+  question_lstm:
+    priority: 1.3
+    type: RecurrentNeuralNetwork
+    cell_type: LSTM
+    prediction_mode: Dense
+    use_logsoftmax: False
+    output_last_state: False
+    initial_state: Trainable
+    dropout_rate: 0.1
+    hidden_size: 50
+    streams:
+      inputs: embedded_questions
+      predictions: question_activations
+    globals:
+      input_size: embeddings_size
+      prediction_size: question_encoder_output_size
+
+  ################# PIPE 3: question attention  #################
+  # Self Attention for question.
+  question_attention:
+    priority: 4.1
+    type: SelfAttention
+    latent_size: 128
+    num_attention_heads: 4
+    streams:
+      question_encodings: question_activations
+      outputs: question_attention_activations
+    globals:
+      question_encoding_size: question_encoder_output_size
+      output_size: attention_activation_size
+
+  classifier:
+    priority: 5.1
+    type: FeedForwardNetwork
+    hidden_sizes: [100]
+    dropout_rate: 0.5
+    streams:
+      inputs: question_attention_activations
+    globals:
+      input_size: attention_activation_size
+      prediction_size: vocabulary_size_c2
+
+
+  #: pipeline

--- a/ptp/components/models/__init__.py
+++ b/ptp/components/models/__init__.py
@@ -14,6 +14,7 @@ from .vqa.multimodal_compact_bilinear_pooling import MultimodalCompactBilinearPo
 from .vqa.relational_network import RelationalNetwork
 from .vqa.attention import VQA_Attention
 from .vqa.multimodal_factorized_bilinear_pooling import MultimodalFactorizedBilinearPooling
+from .vqa.self_attention import SelfAttention
 
 __all__ = [
     'ConvNetEncoder',
@@ -30,5 +31,6 @@ __all__ = [
     'RelationalNetwork',
     'Attn_Decoder_RNN',
     'VQA_Attention',
-    'MultimodalFactorizedBilinearPooling'
+    'MultimodalFactorizedBilinearPooling',
+    'SelfAttention'
     ]

--- a/ptp/components/models/vqa/multimodal_factorized_bilinear_pooling.py
+++ b/ptp/components/models/vqa/multimodal_factorized_bilinear_pooling.py
@@ -27,9 +27,9 @@ import torch.nn.functional as F
 class MultimodalFactorizedBilinearPooling(Model):
     """
     Element of one of the classical baselines for Visual Question Answering.
-    The multi-modal data are fused via sum-pooling of the element-wise multiplied high-dimensional representations and returned (for subsequent classification, done in a separate component e.g. ffn).
+    The multi-modal data is fused via sum-pooling of the element-wise multiplied high-dimensional representations and returned (for subsequent classification, done in a separate component e.g. ffn).
 
-    On the basis of: Zhou Yu, Jun Yu. "Beyond Bilinear: Generalized Multi-modal Factorized High-order Pooling for Visual Question Answering" (2017).
+    On the basis of: Zhou Yu, Jun Yu. "Beyond Bilinear: Generalized Multi-modal Factorized High-order Pooling for Visual Question Answering" (2015).
     Code: https://github.com/Cadene/block.bootstrap.pytorch/blob/master/block/models/networks/fusions/fusions.py
     """
     def __init__(self, name, config):

--- a/ptp/components/models/vqa/self_attention.py
+++ b/ptp/components/models/vqa/self_attention.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) IBM Corporation 2018
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__author__ = "Deepta Rajan"
+
+
+import torch
+
+from ptp.components.models.model import Model
+from ptp.data_types.data_definition import DataDefinition
+
+
+class SelfAttention(Model):
+    """
+    Element of one of the classical baselines for Visual Question Answering.
+    Attention within an image or text is computed.
+    The attention weighted data (question or image) is returned (for subsequent classification, done in a separate component e.g. ffn).
+    Currently only supports self-attention on text data
+
+    On the basis of: Vaswani et. al Attention is all you need (2017)
+
+    """
+    def __init__(self, name, config):
+        """
+        Initializes the model, creates the required layers.
+
+        :param name: Name of the model (taken from the configuration file).
+
+        :param config: Parameters read from configuration file.
+        :type config: ``ptp.configuration.ConfigInterface``
+
+        """
+        super(SelfAttention, self).__init__(name, SelfAttention, config)
+
+        # Get key mappings.
+        self.key_question_encodings = self.stream_keys["question_encodings"]
+        self.key_outputs = self.stream_keys["outputs"]
+
+        # Retrieve input/output sizes from globals.
+        self.question_encoding_size = self.globals["question_encoding_size"]
+
+        # Get size of latent space and number of heads from config.
+        self.latent_size = self.config["latent_size"]
+        self.num_attention_heads = self.config["num_attention_heads"]
+
+        # Output feature size
+        self.output_size = self.question_encoding_size*self.num_attention_heads
+        # Create activation layer.
+        self.activation = torch.nn.ReLU()
+
+        # Create FF layers
+        self.W1 = torch.nn.Linear(self.question_encoding_size, self.latent_size)
+        self.W2 = torch.nn.Linear(self.latent_size, self.num_attention_heads)
+
+
+    def input_data_definitions(self):
+        """
+        Function returns a dictionary with definitions of input data that are required by the component.
+
+        :return: dictionary containing input data definitions (each of type :py:class:`ptp.utils.DataDefinition`).
+        """
+        return {
+            self.key_question_encodings: DataDefinition([-1, -1, self.question_encoding_size], [torch.Tensor], "Batch of encoded questions [BATCH_SIZE x SEQ_LEN x QUESTION_ENCODING_SIZE]"),
+            }
+
+
+    def output_data_definitions(self):
+        """
+        Function returns a dictionary with definitions of output data produced the component.
+
+        :return: dictionary containing output data definitions (each of type :py:class:`ptp.utils.DataDefinition`).
+        """
+        return {
+            self.key_outputs: DataDefinition([-1, self.output_size], [torch.Tensor], "Batch of outputs [BATCH_SIZE x OUTPUT_SIZE]")
+            }
+
+    def forward(self, data_dict):
+        """
+        Main forward pass of the model.
+
+        :param data_dict: DataDict({'images',**})
+        :type data_dict: ``ptp.dadatypes.DataDict``
+        """
+
+        # Unpack DataDict.
+        input_enc = data_dict[self.key_question_encodings] # [batch, num_words, embed_dim] # Dense prediction from RNN
+        batch_size = input_enc.size()[0] # [48, 8, 100]
+
+        # Attention computed as two FF layers with ReLU activation and softmax for probabilities ==> softmax(FF(ReLU(FF(input))))
+        self.Attention = torch.softmax(self.W2(self.activation(self.W1(input_enc))), dim = 1) # [48, 8, 4] [batch, num_words, num_heads]
+
+        # Multiply attention weights with question encoding
+        input_enc_weighted = torch.matmul(self.Attention.transpose(1,2),input_enc)
+        print("input_enc_weighted", input_enc_weighted.shape)
+
+        # Concatenate features from multi-head attention
+        outputs = input_enc_weighted.view(batch_size, -1)
+        # # Alternatively: combine multi-head attention using a mean or sum operation
+        # outputs = torch.sum(input_enc_weighted,1)/self.num_attention_heads
+        print("outputs", outputs.shape)
+
+        # Add predictions to datadict.
+        data_dict.extend({self.key_outputs: outputs})


### PR DESCRIPTION
Multi-head Attention weights are computed using two FF layers with ReLU activation and softmax for probabilities ==> softmax(FF(ReLU(FF(input))))
input = [batch_size, num_words, embed_size]
attention = [batch_size, num_words, num_attention_heads]
input_attention_weighted = [batch_size, num_heads, embed_size]
output = [batch_size, num_heads*embed_size] ==> concatenating multi-head representation