### PR TITLE
Parallel GRU decoder with Banadau-style attention

### DIFF
--- a/configs/mnist/mnist_classification_softmax.yml
+++ b/configs/mnist/mnist_classification_softmax.yml
@@ -1,11 +1,6 @@
 # Load config defining MNIST problems for training, validation and testing.
 default_configs: mnist/default_mnist.yml
 
-training:
-  optimizer:
-    name: SGD
-
-
 pipeline:
   name: mnist_softmax_classifier
 

--- a/configs/vqa_med_2019/c4_classification/c4_enc_attndec_resnet152_ewm_cat_is.yml
+++ b/configs/vqa_med_2019/c4_classification/c4_enc_attndec_resnet152_ewm_cat_is.yml
@@ -49,7 +49,7 @@ pipeline:
     pretrained_embeddings_file: glove.6B.100d.txt
     data_folder: ~/data/vqa-med
     word_mappings_file: questions.all.word.mappings.csv
-    fixed_padding: 10 # The longest question!
+    fixed_padding: 10 # The longest question! max is 19!
     additional_tokens: <PAD>,<EOS>
     streams:
       inputs: questions
@@ -66,7 +66,7 @@ pipeline:
     export_pad_mapping_to_globals: True
     additional_tokens: <PAD>,<EOS>
     eos_token: True
-    fixed_padding: 10 # The longest question!
+    fixed_padding: 10 # The longest question! max is 19!
     streams:
       inputs: answers
       outputs: indexed_answers
@@ -163,7 +163,7 @@ pipeline:
     priority: 4
     hidden_size: 100
     use_logsoftmax: False
-    autoregression_length: 10
+    autoregression_length: 10 # Current implementation requires this value to be equal to fixed_padding in SentenceEmbeddings/Indexer...
     prediction_mode: Dense
     dropout_rate: 0.1
     streams:
@@ -200,8 +200,8 @@ pipeline:
 
   # Prediction decoding.
   prediction_decoder:
-    type: SentenceIndexer
     priority: 10
+    type: SentenceIndexer
     # Reverse mode.
     reverse: True
     # Use distributions as inputs.

--- a/configs/vqa_med_2019/c4_classification/c4_enc_attndec_resnet152_ewm_cat_is.yml
+++ b/configs/vqa_med_2019/c4_classification/c4_enc_attndec_resnet152_ewm_cat_is.yml
@@ -4,12 +4,11 @@ default_configs: vqa_med_2019/default_vqa_med_2019.yml
 # Training parameters:
 training:
   problem:
-    batch_size: 64
+    batch_size: 200 # requires to use 4 GPUs!
     categories: C4
     question_preprocessing: lowercase, remove_punctuation, tokenize #, random_remove_stop_words #,random_shuffle_words 
     answer_preprocessing: lowercase, remove_punctuation, tokenize
     export_sample_weights: ~/data/vqa-med/answers.c4.weights.csv
-    batch_size: 32
   sampler:
     weights: ~/data/vqa-med/answers.c4.weights.csv
   dataloader:
@@ -23,11 +22,10 @@ training:
 # Validation parameters:
 validation:
   problem:
-    batch_size: 64
+    batch_size: 200
     categories: C4
     question_preprocessing: lowercase, remove_punctuation, tokenize
     answer_preprocessing: lowercase, remove_punctuation, tokenize
-    batch_size: 32
   dataloader:
     num_workers: 4
 

--- a/configs/vqa_med_2019/c4_classification/c4_enc_attndec_resnet152_ewm_cat_is.yml
+++ b/configs/vqa_med_2019/c4_classification/c4_enc_attndec_resnet152_ewm_cat_is.yml
@@ -49,7 +49,7 @@ pipeline:
     pretrained_embeddings_file: glove.6B.100d.txt
     data_folder: ~/data/vqa-med
     word_mappings_file: questions.all.word.mappings.csv
-    fixed_padding: 10
+    fixed_padding: 10 # The longest question!
     additional_tokens: <PAD>,<EOS>
     streams:
       inputs: questions
@@ -66,7 +66,7 @@ pipeline:
     export_pad_mapping_to_globals: True
     additional_tokens: <PAD>,<EOS>
     eos_token: True
-    fixed_padding: 10
+    fixed_padding: 10 # The longest question!
     streams:
       inputs: answers
       outputs: indexed_answers
@@ -88,9 +88,11 @@ pipeline:
 
   # Single layer GRU Encoder
   encoder:
-    type: RecurrentNeuralNetwork
-    cell_type: GRU
     priority: 3
+    type: RecurrentNeuralNetwork
+    # Do not wrap that model with DataDictParallel!
+    parallelize: False
+    cell_type: GRU
     initial_state: Trainable
     hidden_size: 100
     num_layers: 1
@@ -110,7 +112,7 @@ pipeline:
   reshaper_1:
     priority: 3.01
     type: ReshapeTensor
-    input_dims: [1, -1, 100]
+    input_dims: [-1, 1, 100]
     output_dims: [-1, 100]
     streams:
       inputs: s2s_state_output
@@ -148,7 +150,7 @@ pipeline:
     priority: 3.3
     type: ReshapeTensor
     input_dims: [-1, 100]
-    output_dims: [1, -1, 100]
+    output_dims: [-1, 1, 100]
     streams:
       inputs: question_image_activations
       outputs: question_image_activations_reshaped

--- a/ptp/components/models/attn_decoder_rnn.py
+++ b/ptp/components/models/attn_decoder_rnn.py
@@ -185,14 +185,13 @@ class Attn_Decoder_RNN(Model):
         
         inputs = data_dict[self.key_inputs]
         batch_size = inputs.shape[0]
-        print("{}: input shape: {}, device: {}\n".format(self.name, inputs.shape, inputs.device))
+        #print("{}: input shape: {}, device: {}\n".format(self.name, inputs.shape, inputs.device))
 
         # Initialize hidden state from inputs - as last hidden state from external component.
         hidden = data_dict[self.key_input_state]
         # For RNNs (aside of LSTM): [BATCH_SIZE x NUM_LAYERS x HIDDEN_SIZE] -> [NUM_LAYERS x BATCH_SIZE x HIDDEN_SIZE]
         hidden = hidden.transpose(0,1)
-        print("{}: hidden shape: {}, device: {}\n".format(self.name, hidden.shape, hidden.device))
-
+        #print("{}: hidden shape: {}, device: {}\n".format(self.name, hidden.shape, hidden.device))
 
         # List that will contain the output sequence
         activations = []

--- a/ptp/components/models/attn_decoder_rnn.py
+++ b/ptp/components/models/attn_decoder_rnn.py
@@ -82,7 +82,7 @@ class Attn_Decoder_RNN(Model):
         # Create dropout layer.
         self.dropout = torch.nn.Dropout(dropout_rate)
 
-        # Create rnn cell.
+        # Create rnn cell: hardcoded one layer GRU.
         self.rnn_cell = getattr(torch.nn, "GRU")(self.input_size, self.hidden_size, 1, dropout=dropout_rate, batch_first=True)
 
         # Create layers for the attention
@@ -149,7 +149,7 @@ class Attn_Decoder_RNN(Model):
         d[self.key_inputs] = DataDefinition([-1, -1, self.hidden_size], [torch.Tensor], "Batch of encoder outputs [BATCH_SIZE x SEQ_LEN x INPUT_SIZE]")
 
         # Input hidden state
-        d[self.key_input_state] = DataDefinition([1, -1, self.hidden_size], [torch.Tensor], "Batch of RNN last states")
+        d[self.key_input_state] = DataDefinition([-1, 1, self.hidden_size], [torch.Tensor], "Batch of RNN last hidden states passed from another RNN that will be used as initial [BATCH_SIZE x NUM_LAYERS x SEQ_LEN x HIDDEN_SIZE]")
 
         return d
 
@@ -167,9 +167,9 @@ class Attn_Decoder_RNN(Model):
             # Only last prediction.
             d[self.key_predictions] = DataDefinition([-1, self.prediction_size], [torch.Tensor], "Batch of predictions, each represented as probability distribution over classes [BATCH_SIZE x SEQ_LEN x PREDICTION_SIZE]")
 
-        # Output hidden state stream
+        # Output hidden state stream TODO: why do we need that?
         if self.output_last_state:
-            d[self.key_output_state] = DataDefinition([1, -1, self.hidden_size], [torch.Tensor], "Batch of RNN last states")
+            d[self.key_output_state] = DataDefinition([-1, 1, self.hidden_size], [torch.Tensor], "Batch of RNN final hidden states [BATCH_SIZE x NUM_LAYERS x SEQ_LEN x HIDDEN_SIZE]")
         
         return d
 
@@ -185,9 +185,14 @@ class Attn_Decoder_RNN(Model):
         
         inputs = data_dict[self.key_inputs]
         batch_size = inputs.shape[0]
+        print("{}: input shape: {}, device: {}\n".format(self.name, inputs.shape, inputs.device))
 
-        # Initialize hidden state.
+        # Initialize hidden state from inputs - as last hidden state from external component.
         hidden = data_dict[self.key_input_state]
+        # For RNNs (aside of LSTM): [BATCH_SIZE x NUM_LAYERS x HIDDEN_SIZE] -> [NUM_LAYERS x BATCH_SIZE x HIDDEN_SIZE]
+        hidden = hidden.transpose(0,1)
+        print("{}: hidden shape: {}, device: {}\n".format(self.name, hidden.shape, hidden.device))
+
 
         # List that will contain the output sequence
         activations = []
@@ -232,4 +237,7 @@ class Attn_Decoder_RNN(Model):
 
         # Output last hidden state, if requested
         if self.output_last_state:
+            # For others: [NUM_LAYERS x BATCH_SIZE x HIDDEN_SIZE] -> [BATCH_SIZE x NUM_LAYERS x HIDDEN_SIZE] 
+            hidden = hidden.transpose(0,1)
+            # Export last hidden state.
             data_dict.extend({self.key_output_state: hidden})

--- a/ptp/components/models/recurrent_neural_network.py
+++ b/ptp/components/models/recurrent_neural_network.py
@@ -285,10 +285,7 @@ class RecurrentNeuralNetwork(Model):
             if inputs.dim() == 2:
                 inputs = inputs.unsqueeze(1)
             batch_size = inputs.shape[0]
-
-        print("{}: input shape: {}, device: {}\n".format(self.name, inputs.shape, inputs.device))
-
-        
+        #print("{}: input shape: {}, device: {}\n".format(self.name, inputs.shape, inputs.device))
 
         # Get initial state, depending on the settings.
         if self.initial_state == "Input":
@@ -303,8 +300,7 @@ class RecurrentNeuralNetwork(Model):
                 hidden = hidden.transpose(0,1)
         else:
             hidden = self.initialize_hiddens_state(batch_size)
-
-        print("{}: hidden shape: {}, device: {}\n".format(self.name, hidden.shape, hidden.device))
+        #print("{}: hidden shape: {}, device: {}\n".format(self.name, hidden.shape, hidden.device))
 
         activations = []
 

--- a/ptp/components/models/sentence_embeddings.py
+++ b/ptp/components/models/sentence_embeddings.py
@@ -111,7 +111,7 @@ class SentenceEmbeddings(Model, WordMappings):
         # Unpack DataDict.
         inputs = data_dict[self.key_inputs]
 
-        #print("{}: input len: {}, device: {}\n".format(self.name, len(inputs), "-"))
+        print("{}: input len: {}, device: {}\n".format(self.name, len(inputs), "-"))
 
         # Get index of padding.
         pad_index = self.word_to_ix['<PAD>']
@@ -163,7 +163,7 @@ class SentenceEmbeddings(Model, WordMappings):
         padded_indices = torch.nn.utils.rnn.pad_sequence(indices_list, batch_first=True, padding_value=pad_index)
         embedds = self.embeddings(padded_indices)
         
-        #print("{}: embedds shape: {}, device: {}\n".format(self.name, embedds.shape, embedds.device))
+        print("{}: embedds shape: {}, device: {}\n".format(self.name, embedds.shape, embedds.device))
 
         # Add embeddings to datadict.
         data_dict.extend({self.key_outputs: embedds})

--- a/ptp/components/models/sentence_embeddings.py
+++ b/ptp/components/models/sentence_embeddings.py
@@ -110,8 +110,7 @@ class SentenceEmbeddings(Model, WordMappings):
 
         # Unpack DataDict.
         inputs = data_dict[self.key_inputs]
-
-        print("{}: input len: {}, device: {}\n".format(self.name, len(inputs), "-"))
+        #print("{}: input len: {}, device: {}\n".format(self.name, len(inputs), "-"))
 
         # Get index of padding.
         pad_index = self.word_to_ix['<PAD>']
@@ -137,33 +136,13 @@ class SentenceEmbeddings(Model, WordMappings):
             #indices_list.append(self.app_state.FloatTensor(output_sample))
             indices_list.append(self.app_state.LongTensor(output_sample))
 
-        # Create list of (index,len) tuples.
-        #order_len = [(i, len(indices_list[i])) for i in range(len(indices_list))]
-
-        # Sort by seq_length.
-        #sorted_order_len = sorted(order_len, key=lambda x: x[1], reverse=True)
-
-        # Now sort indices list.
-        #sorted_indices_list = [indices_list[sorted_order_len[i][0]] for i in range(len(indices_list))]
-
-        # Pad the indices list.
-        #padded_indices = torch.nn.utils.rnn.pad_sequence(sorted_indices_list, batch_first=True)
-
-        # Revert to the original batch order!!!
-        #new_old_order = [(i, sorted_order_len[i][0]) for i in range(len(indices_list))]
-        #sorted_new_old_order = sorted(new_old_order, key=lambda x: x[1])
-        #unsorted_padded_indices = [padded_indices[sorted_new_old_order[i][0]] for i in range(len(indices_list))]
-        
-        # Change to tensor.
-        #unsorted_padded_indices_tensor = torch.stack( [self.app_state.FloatTensor(lst) for lst in unsorted_padded_indices] )
-
         # Embedd indices.
         #embedds = self.embeddings(unsorted_padded_indices_tensor)
 
         padded_indices = torch.nn.utils.rnn.pad_sequence(indices_list, batch_first=True, padding_value=pad_index)
         embedds = self.embeddings(padded_indices)
         
-        print("{}: embedds shape: {}, device: {}\n".format(self.name, embedds.shape, embedds.device))
+        #print("{}: embedds shape: {}, device: {}\n".format(self.name, embedds.shape, embedds.device))
 
         # Add embeddings to datadict.
         data_dict.extend({self.key_outputs: embedds})

--- a/ptp/components/utils/word_mappings.py
+++ b/ptp/components/utils/word_mappings.py
@@ -146,13 +146,14 @@ def pad_trunc_list(l: list, length: int, padding_value = 0, eos_value = None):
 
     :return: None
     """
-    
     if len(l) < length:
         if eos_value is not None:
             l.append(eos_value)
         l.extend([padding_value]*(length-len(l)))
         
     elif len(l) > length:
+        #print("pad_trunc_list to cat!: {}".format(len(l)))
         del l[length:]
         if eos_value is not None:
             l[length-1] = eos_value
+        #exit(1)

--- a/ptp/components/utils/word_mappings.py
+++ b/ptp/components/utils/word_mappings.py
@@ -153,7 +153,7 @@ def pad_trunc_list(l: list, length: int, padding_value = 0, eos_value = None):
         
     elif len(l) > length:
         #print("pad_trunc_list to cat!: {}".format(len(l)))
+        #exit(1)
         del l[length:]
         if eos_value is not None:
             l[length-1] = eos_value
-        #exit(1)


### PR DESCRIPTION
- Fixes issues with description of hidden stream in decoder with attention (it actually required different order than defined in output_data_definitions)
- Standardized dimensions of input/output hidden steams in both RNN models: batch-major!

That, along with fixed sizes of embeddings (padding) enabled to properly parallelize both the model and C4 pipeline