### PR TITLE
VQA MED add-ons

### DIFF
--- a/configs/default/components/problems/image_text_to_class/vqa_med_2019.yml
+++ b/configs/default/components/problems/image_text_to_class/vqa_med_2019.yml
@@ -15,6 +15,9 @@ split: training
 # Options: all | c1 | c2 | c3 | c4 (or any combination of the latter 4)
 categories: all
 
+# Flag indicating whether the problem will load and return images (LOADED)
+stream_images: True
+
 # Resize parameter (LOADED)
 # When present, resizes the images from original size to [height, width]
 # Depth remains set to 3.

--- a/configs/default/components/problems/image_text_to_class/vqa_med_2019.yml
+++ b/configs/default/components/problems/image_text_to_class/vqa_med_2019.yml
@@ -18,6 +18,11 @@ categories: all
 # Flag indicating whether the problem will load and return images (LOADED)
 stream_images: True
 
+# Flag indicating whether images will be preloaded (i.e. loaded once at start) (LOADED)
+# WARNING: if this option is active, the images will also be "preprocessed" at start.
+# This means that preloading should not be used when one needs to use the random augmentations!
+preload_images: False
+
 # Resize parameter (LOADED)
 # When present, resizes the images from original size to [height, width]
 # Depth remains set to 3.

--- a/configs/vqa_med_2019/c4_classification/c4_word_answer_onehot_bow.yml
+++ b/configs/vqa_med_2019/c4_classification/c4_word_answer_onehot_bow.yml
@@ -1,9 +1,28 @@
 # Load config defining problems for training, validation and testing.
 default_configs: vqa_med_2019/c4_classification/default_c4_classification.yml
 
-pipeline:
-  name: c4_word_answer_onehot_bow
+# Training parameters:
+training:
+  problem:
+    categories: C4
+    batch_size: 512
+    # In here we won't use images at all.
+    stream_images: False
+  dataloader:
+    num_workers: 0
+    
+# Validation parameters:
+validation:
+  problem:
+    categories: C4
+    batch_size: 512
+    # In here we won't use images at all.
+    stream_images: False
+  dataloader:
+    num_workers: 0
 
+
+pipeline:
   # Answer encoding.
   answer_tokenizer:
     type: SentenceTokenizer

--- a/configs/vqa_med_2019/evaluation/mimic_lstm_vgg16_ewm_is_cat_ffn_c123_loss.yml
+++ b/configs/vqa_med_2019/evaluation/mimic_lstm_vgg16_ewm_is_cat_ffn_c123_loss.yml
@@ -38,7 +38,9 @@ hyperparameters:
   # Final classifier: FFN.
   answer_classifier_hidden_sizes_val: &answer_classifier_hidden_sizes_val [83]
 
-  batch_size: &batch_size 64
+  batch_size: &batch_size 200
+  preload_images: &preload_images True
+  num_workers: &num_workers 0
 
 # Training parameters:
 training:
@@ -49,10 +51,15 @@ training:
     # Appy all preprocessing/data augmentations.
     question_preprocessing: *question_preprocessing
     image_preprocessing: *image_preprocessing 
+    # Preload images.
+    preload_images: *preload_images
     streams: 
       questions: tokenized_questions
   sampler:
     weights: ~/data/vqa-med/answers.c1_c2_c3_binary_yn.weights.csv
+  # Use four workers for loading images.
+  dataloader:
+    num_workers: *num_workers
 
   # Optimizer parameters:
   optimizer:
@@ -67,14 +74,19 @@ training:
 
 # Validation parameters:
 validation:
+  partial_validation_interval: 100
   problem:
     batch_size: *batch_size
     categories: C1,C2,C3
     # Appy all preprocessing/data augmentations.
     question_preprocessing: *question_preprocessing
     image_preprocessing: *image_preprocessing 
+    # Preload images.
+    preload_images: *preload_images
     streams: 
       questions: tokenized_questions
+  dataloader:
+    num_workers: *num_workers
 
 
 pipeline:


### PR DESCRIPTION
Added two flags to problem configuration:
  - **stream_images** (DEFAULT: True) Flag indicating whether the problem will load and return images 

  - **preload_images** (DEFAULT: False) Flag indicating whether images will be preloaded (i.e. loaded once at start)

**stream_images** gives huge boost when working with question/answer pipelines.

WARNING: if **preload_images**  option is active, the images will also be "preprocessed" at start. This means that preloading should not be used when one needs to use the random augmentations!

Using the preload_images option takes some time at the beginning, but during training/batch processing it is comparable (when it comes to time) to using DataLoader with 4 workers, **with the advantage is lower utilization of CPU(s)**.

Some results on mimic_lstm_vgg16_ewm_is_cat_ffn_c1_loss (C1 problem, batch_size = 200, 2 GPUs):
  - preload_images: True, workers: 0, (avg) single epoch time: 33(s)
  - preload_images: False, workers: 0, (avg) single epoch time: 50(s)
  - preload_images: False, workers: 1, (avg) single epoch time: 37(s)
  - preload_images: False, workers: 4, (avg) single epoch time: 34(s)

