### PR TITLE
C4 answer-word classifiers, C123 - configs for evaluation

### DIFF
--- a/configs/default/components/models/sentence_embeddings.yml
+++ b/configs/default/components/models/sentence_embeddings.yml
@@ -40,7 +40,9 @@ fixed_padding: -1
 
 # File containing pretrained embeddings (LOADED)
 # Empty means that no embeddings will be loaded.
-# Options: '' | glove.6B.50d.txt | glove.6B.100d.txt | glove.6B.200d.txt | glove.6B.300d.txt | glove.42B.300d.txt | glove.840B.300d.txt | glove.twitter.27B.txt | mimic.fastText.no_clean.300d.pickled
+# Options: 
+# '' | glove.6B.50d.txt | glove.6B.100d.txt | glove.6B.200d.txt | glove.6B.300d.txt |
+# glove.42B.300d.txt | glove.840B.300d.txt | glove.twitter.27B.txt | mimic.fastText.no_clean.300d.pickled
 pretrained_embeddings_file: ''
 
 streams: 

--- a/configs/default/components/models/vqa/multimodal_compact_bilinear_pooling.yml
+++ b/configs/default/components/models/vqa/multimodal_compact_bilinear_pooling.yml
@@ -4,6 +4,10 @@
 # 1. CONFIGURATION PARAMETERS that will be LOADED by the component.
 ####################################################################
 
+# Parameter denoting whether projection matrices are trainable (LOADED)
+# Setting flag that to true will result in trainable, dense (i.e. not "sketch") projection layers.
+trainable_projections: False
+
 streams: 
   ####################################################################
   # 2. Keymappings associated with INPUT and OUTPUT streams.

--- a/configs/default/components/transforms/reduce_tensor.yml
+++ b/configs/default/components/transforms/reduce_tensor.yml
@@ -1,32 +1,31 @@
-# This file defines the default values for the VQA_Attention model.
+# This file defines the default values for the ReduceTensor transformation.
 
 ####################################################################
 # 1. CONFIGURATION PARAMETERS that will be LOADED by the component.
 ####################################################################
 
-# Dropout rate (LOADED)
-# Default: 0 (means that it is turned off)
-dropout_rate: 0
+# Number of input dimensions, including batch (LOADED)
+num_inputs_dims: 2
 
-# Size of the latent space (LOADED)
-latent_size: 100
+# Dimension along with the reduction will be applied (LOADED)
+reduction_dim: 1
 
-# Number of attention heads (LOADED)
-num_attention_heads: 2
+# Reduction type (LOADED)
+# Options: sum | mean | min | max | argmin | argmax
+reduction_type: sum
 
+# If True, the output tensor is of the same size as input, except dim where it is of size 1 (LOADED)
+keepdim: False
 
-streams:
+streams: 
   ####################################################################
   # 2. Keymappings associated with INPUT and OUTPUT streams.
   ####################################################################
 
-  # Stream containing batch of encoded images (INPUT)
-  feature_maps: feature_maps
+  # Stream containing input tensor (INPUT)
+  inputs: inputs
 
-  # Stream containing batch of encoded questions (INPUT)
-  question_encodings: question_encodings
-
-  # Stream containing outputs (OUTPUT)
+  # Stream containing output tensor (OUTPUT)
   outputs: outputs
 
 globals:
@@ -34,25 +33,15 @@ globals:
   # 3. Keymappings of variables that will be RETRIEVED from GLOBALS.
   ####################################################################
 
-  # Height of the features tensor (RETRIEVED)
-  feature_maps_height: feature_maps_height
-
-  # Width of the features tensor (RETRIEVED)
-  feature_maps_width: feature_maps_width
-
-  # Depth of the features tensor (RETRIEVED)
-  feature_maps_depth: feature_maps_depth
-  
-  # Size of the question encodings input (RETRIEVED)
-  question_encoding_size: question_encoding_size
+  # Size of the intput_item (GET)
+  # (last dimenstion)
+  input_size: input_size
 
   ####################################################################
   # 4. Keymappings associated with GLOBAL variables that will be SET.
   ####################################################################
 
-  # Size of the output (SET)
-  output_size: output_size
-
   ####################################################################
   # 5. Keymappings associated with statistics that will be ADDED.
   ####################################################################
+

--- a/configs/vqa_med_2019/c2_classification/c2_classification_all_rnn_vgg16_mcb.yml
+++ b/configs/vqa_med_2019/c2_classification/c2_classification_all_rnn_vgg16_mcb.yml
@@ -8,7 +8,7 @@ pipeline:
     type: GlobalVariablePublisher
     # Add input_size to globals.
     keys: [question_encoder_output_size, image_encoder_output_size, fused_image_question_activation_size]
-    values: [200, 1000, 100]
+    values: [200, 500, 100]
 
   ################# PIPE 0: question #################
   # Questions encoding.

--- a/configs/vqa_med_2019/c4_classification/c4_word_answer_glove_sum.yml
+++ b/configs/vqa_med_2019/c4_classification/c4_word_answer_glove_sum.yml
@@ -1,0 +1,91 @@
+# Load config defining problems for training, validation and testing.
+default_configs: vqa_med_2019/c4_classification/default_c4_classification.yml
+
+# Training parameters:
+training:
+  problem:
+    categories: C4
+    batch_size: 512
+    # In here we won't use images at all.
+    stream_images: False
+  dataloader:
+    num_workers: 0
+    
+# Validation parameters:
+validation:
+  problem:
+    categories: C4
+    batch_size: 512
+    # In here we won't use images at all.
+    stream_images: False
+  dataloader:
+    num_workers: 0
+
+
+pipeline:
+
+  global_publisher:
+    priority: 0
+    type: GlobalVariablePublisher
+    # Add input_size to globals.
+    keys: [answer_word_embeddings_size]
+    values: [100]
+
+  # Answer encoding.
+  answer_tokenizer:
+    type: SentenceTokenizer
+    priority: 1.1
+    preprocessing: lowercase,remove_punctuation
+    remove_characters: [“,”,’]
+    streams: 
+      inputs: answers
+      outputs: tokenized_answer_words
+
+  # Model 1: Embeddings
+  answer_embeddings:
+    priority: 1.2
+    type: SentenceEmbeddings
+    embeddings_size: 100
+    pretrained_embeddings_file: glove.6B.100d.txt
+    data_folder: ~/data/vqa-med
+    word_mappings_file: answer_words.c4.preprocessed.word.mappings.csv
+    export_word_mappings_to_globals: True
+    streams:
+      inputs: tokenized_answer_words
+      outputs: encoded_answer_words
+    globals:
+      vocabulary_size: answer_words_vocabulary_size
+      word_mappings: answer_words_word_mappings
+
+  answer_reduction:
+    type: ReduceTensor
+    priority: 1.3
+    num_inputs_dims: 3
+    reduction_dim: 1
+    reduction_type: sum
+    keepdim: False
+    streams:
+      inputs: encoded_answer_words
+      outputs: reduced_answers
+    globals:
+      input_size: answer_word_embeddings_size
+
+  # Model.
+  classifier:
+    type: FeedForwardNetwork 
+    hidden_sizes: [500, 500]
+    dropout_rate: 0.5
+    priority: 3
+    streams:
+      inputs: reduced_answers
+    globals:
+      input_size: answer_word_embeddings_size
+      prediction_size: vocabulary_size_c4
+
+   # Viewers.
+  viewer:
+    type: StreamViewer
+    priority: 100.4
+    input_streams: answers, tokenized_answer_words, predicted_answers
+ 
+#: pipeline

--- a/configs/vqa_med_2019/c4_classification/c4_word_answer_mimic_sum.yml
+++ b/configs/vqa_med_2019/c4_classification/c4_word_answer_mimic_sum.yml
@@ -1,0 +1,91 @@
+# Load config defining problems for training, validation and testing.
+default_configs: vqa_med_2019/c4_classification/default_c4_classification.yml
+
+# Training parameters:
+training:
+  problem:
+    categories: C4
+    batch_size: 512
+    # In here we won't use images at all.
+    stream_images: False
+  dataloader:
+    num_workers: 0
+    
+# Validation parameters:
+validation:
+  problem:
+    categories: C4
+    batch_size: 512
+    # In here we won't use images at all.
+    stream_images: False
+  dataloader:
+    num_workers: 0
+
+
+pipeline:
+
+  global_publisher:
+    priority: 0
+    type: GlobalVariablePublisher
+    # Add input_size to globals.
+    keys: [answer_word_embeddings_size]
+    values: [300]
+
+  # Answer encoding.
+  answer_tokenizer:
+    type: SentenceTokenizer
+    priority: 1.1
+    preprocessing: lowercase,remove_punctuation
+    remove_characters: [“,”,’]
+    streams: 
+      inputs: answers
+      outputs: tokenized_answer_words
+
+  # Model 1: Embeddings
+  answer_embeddings:
+    priority: 1.2
+    type: SentenceEmbeddings
+    embeddings_size: 300
+    pretrained_embeddings_file: mimic.fastText.no_clean.300d.pickled
+    data_folder: ~/data/vqa-med
+    word_mappings_file: answer_words.c4.preprocessed.word.mappings.csv
+    export_word_mappings_to_globals: True
+    streams:
+      inputs: tokenized_answer_words
+      outputs: encoded_answer_words
+    globals:
+      vocabulary_size: answer_words_vocabulary_size
+      word_mappings: answer_words_word_mappings
+
+  answer_reduction:
+    type: ReduceTensor
+    priority: 1.3
+    num_inputs_dims: 3
+    reduction_dim: 1
+    reduction_type: sum
+    keepdim: False
+    streams:
+      inputs: encoded_answer_words
+      outputs: reduced_answers
+    globals:
+      input_size: answer_word_embeddings_size
+
+  # Model.
+  classifier:
+    type: FeedForwardNetwork 
+    hidden_sizes: [500, 500]
+    dropout_rate: 0.5
+    priority: 3
+    streams:
+      inputs: reduced_answers
+    globals:
+      input_size: answer_word_embeddings_size
+      prediction_size: vocabulary_size_c4
+
+   # Viewers.
+  viewer:
+    type: StreamViewer
+    priority: 100.4
+    input_streams: answers, tokenized_answer_words, predicted_answers
+ 
+#: pipeline

--- a/configs/vqa_med_2019/c4_classification/c4_word_answer_onehot_sum.yml
+++ b/configs/vqa_med_2019/c4_classification/c4_word_answer_onehot_sum.yml
@@ -1,0 +1,91 @@
+# Load config defining problems for training, validation and testing.
+default_configs: vqa_med_2019/c4_classification/default_c4_classification.yml
+
+# Training parameters:
+training:
+  problem:
+    categories: C4
+    batch_size: 512
+    # In here we won't use images at all.
+    stream_images: False
+  dataloader:
+    num_workers: 0
+    
+# Validation parameters:
+validation:
+  problem:
+    categories: C4
+    batch_size: 512
+    # In here we won't use images at all.
+    stream_images: False
+  dataloader:
+    num_workers: 0
+
+
+pipeline:
+  # Answer encoding.
+  answer_tokenizer:
+    type: SentenceTokenizer
+    priority: 1.1
+    preprocessing: lowercase,remove_punctuation
+    remove_characters: [“,”,’]
+    streams: 
+      inputs: answers
+      outputs: tokenized_answer_words
+
+  answer_onehot_encoder:
+    type: SentenceOneHotEncoder
+    priority: 1.2
+    data_folder: ~/data/vqa-med
+    word_mappings_file: answer_words.c4.preprocessed.word.mappings.csv
+    export_word_mappings_to_globals: True
+    streams:
+      inputs: tokenized_answer_words
+      outputs: encoded_answer_words
+    globals:
+      vocabulary_size: answer_words_vocabulary_size
+      word_mappings: answer_words_word_mappings
+
+  answer_to_tensor:
+    type: ListToTensor
+    priority: 1.3
+    num_inputs_dims: 3
+    streams:
+      inputs: encoded_answer_words
+      outputs: tensor_answer_words
+    globals:
+      input_size: answer_words_vocabulary_size
+
+
+  answer_reduction:
+    type: ReduceTensor
+    priority: 1.4
+    num_inputs_dims: 3
+    reduction_dim: 1
+    reduction_type: sum
+    keepdim: False
+    streams:
+      inputs: tensor_answer_words
+      outputs: reduced_answer_words
+    globals:
+      input_size: answer_words_vocabulary_size
+
+  # Model.
+  classifier:
+    type: FeedForwardNetwork 
+    hidden_sizes: [500, 500]
+    dropout_rate: 0.5
+    priority: 3
+    streams:
+      inputs: reduced_answer_words
+    globals:
+      input_size: answer_words_vocabulary_size
+      prediction_size: vocabulary_size_c4
+
+   # Viewers.
+  viewer:
+    type: StreamViewer
+    priority: 100.4
+    input_streams: answers, tokenized_answer_words, predicted_answers
+ 
+#: pipeline

--- a/configs/vqa_med_2019/c4_classification/default_c4_classification.yml
+++ b/configs/vqa_med_2019/c4_classification/default_c4_classification.yml
@@ -70,8 +70,8 @@ pipeline:
     type: PrecisionRecallStatistics
     priority: 100.3
     use_word_mappings: True
-    show_class_scores: True
-    show_confusion_matrix: True
+    #show_class_scores: True
+    #show_confusion_matrix: True
     streams:
       targets: answers_ids
     globals:

--- a/configs/vqa_med_2019/evaluation/example_mimic_lstm_vgg16_ewm_is_cat_ffn_c123_loss.yml
+++ b/configs/vqa_med_2019/evaluation/example_mimic_lstm_vgg16_ewm_is_cat_ffn_c123_loss.yml
@@ -38,9 +38,10 @@ hyperparameters:
   # Final classifier: FFN.
   answer_classifier_hidden_sizes_val: &answer_classifier_hidden_sizes_val [83]
 
+  # Parameters related to GPU/CPU distribution.
   batch_size: &batch_size 200
   preload_images: &preload_images True
-  num_workers: &num_workers 0
+  num_workers: &num_workers 1
 
 # Training parameters:
 training:

--- a/configs/vqa_med_2019/evaluation/glove_lstm_resnet50_ewm_is_cat_ffn_c123_loss.yml
+++ b/configs/vqa_med_2019/evaluation/glove_lstm_resnet50_ewm_is_cat_ffn_c123_loss.yml
@@ -39,6 +39,8 @@ hyperparameters:
   answer_classifier_hidden_sizes_val: &answer_classifier_hidden_sizes_val [100]
 
   batch_size: &batch_size 64
+  preload_images: &preload_images True
+  num_workers: &num_workers 0
 
 # Training parameters:
 training:
@@ -49,10 +51,15 @@ training:
     # Appy all preprocessing/data augmentations.
     question_preprocessing: *question_preprocessing
     image_preprocessing: *image_preprocessing 
+    # Preload images.
+    preload_images: *preload_images
     streams: 
       questions: tokenized_questions
   sampler:
     weights: ~/data/vqa-med/answers.c1_c2_c3_binary_yn.weights.csv
+  # Use four workers for loading images.
+  dataloader:
+    num_workers: *num_workers
 
   # Optimizer parameters:
   optimizer:
@@ -67,17 +74,26 @@ training:
 
 # Validation parameters:
 validation:
+  partial_validation_interval: 100
   problem:
     batch_size: *batch_size
     categories: C1,C2,C3
     # Appy all preprocessing/data augmentations.
     question_preprocessing: *question_preprocessing
     image_preprocessing: *image_preprocessing 
+    # Preload images: false, as we will need them only once, at the end.
+    preload_images: false
     streams: 
       questions: tokenized_questions
+  dataloader:
+    num_workers: 1
 
 
 pipeline:
+  # Disable flow 0.
+  disable: 
+    pipe0_question_embeddings,pipe0_question_embeddings,pipe0_lstm,pipe0_classifier,
+    pipe0_category_decoder,pipe0_category_accuracy
   
   ################# PIPE 0: SHARED #################
 

--- a/configs/vqa_med_2019/evaluation/tom/glove_lstm_resnet152_att_is_cat_ffn_c123_loss.yml
+++ b/configs/vqa_med_2019/evaluation/tom/glove_lstm_resnet152_att_is_cat_ffn_c123_loss.yml
@@ -13,32 +13,34 @@ hyperparameters:
   # none | random_affine | random_horizontal_flip | normalize | all
 
   # Image encoder.
-  image_encoder_model: &image_encoder_model resnet50
+  image_encoder_model: &image_encoder_model resnet152
   # Options: vgg16 | densenet121 | resnet152 | resnet50
-  image_encoder_output_size_val: &image_encoder_output_size_val 74
+  #image_encoder_output_size_val: &image_encoder_output_size_val 100
+  # INFO: this variable is not important, as we are using features in this pipeline!!
   
   # Question encoder.
-  question_encoder_embeddings: &question_encoder_embeddings mimic.fastText.no_clean.300d.pickled
+  question_encoder_embeddings: &question_encoder_embeddings glove.6B.50d.txt
   # Options: '' | glove.6B.50d.txt | glove.6B.100d.txt | glove.6B.200d.txt | glove.6B.300d.txt | glove.42B.300d.txt | glove.840B.300d.txt | glove.twitter.27B.txt | mimic.fastText.no_clean.300d.pickled
-  question_encoder_embeddings_size_val: &question_encoder_embeddings_size_val 300
-  question_encoder_lstm_size_val: &question_encoder_lstm_size_val 101
-  question_encoder_output_size_val: &question_encoder_output_size_val 103
+  question_encoder_embeddings_size_val: &question_encoder_embeddings_size_val 50
+  question_encoder_lstm_size_val: &question_encoder_lstm_size_val 50
+  question_encoder_output_size_val: &question_encoder_output_size_val 100
   
   # Fusion I: image + question
-  question_image_fusion_type_val: &question_image_fusion_type ElementWiseMultiplication
-  # Options: ElementWiseMultiplication | ? (component: question_image_fusion)
-  question_image_fusion_size_val: &question_image_fusion_size_val 115
+  question_image_fusion_type_val: &question_image_fusion_type VQA_Attention
+  # Options: ElementWiseMultiplication | VQA_Attention
+  #question_image_fusion_size_val: &question_image_fusion_size_val 1124
+  # INFO: this variable is set by VQA_Attention component!
 
   # Image size encoder.
-  image_size_encoder_output_size_val: &image_size_encoder_output_size_val 11
+  image_size_encoder_output_size_val: &image_size_encoder_output_size_val 10
 
   # Fusion II: (image + question) + image size (must be = question_image_fusion_size_val + image_size_encoder_output_size_val)
-  question_image_size_fusion_size_val: &question_image_size_fusion_size_val 126
+  question_image_size_fusion_size_val: &question_image_size_fusion_size_val 1134
 
   # Final classifier: FFN.
-  answer_classifier_hidden_sizes_val: &answer_classifier_hidden_sizes_val [83]
+  answer_classifier_hidden_sizes_val: &answer_classifier_hidden_sizes_val [500]
 
-  batch_size: &batch_size 200
+  batch_size: &batch_size 256
   preload_images: &preload_images True
   num_workers: &num_workers 0
 
@@ -102,8 +104,8 @@ pipeline:
     priority: 0
     type: GlobalVariablePublisher
     # Add input_size to globals.
-    keys: [question_encoder_output_size, image_size_encoder_input_size, image_size_encoder_output_size, image_encoder_output_size, fused_activation_size]
-    values: [*question_encoder_output_size_val, 2, *image_size_encoder_output_size_val, *image_encoder_output_size_val, *question_image_fusion_size_val]
+    keys: [question_encoder_output_size, image_size_encoder_input_size, image_size_encoder_output_size] #, image_encoder_output_size] #, fused_activation_size]
+    values: [*question_encoder_output_size_val, 2, *image_size_encoder_output_size_val] #, *image_encoder_output_size_val] #, *question_image_fusion_size_val]
 
   # Statistics.
   batch_size:
@@ -256,11 +258,10 @@ pipeline:
     priority: 2.1
     type: TorchVisionWrapper
     model: *image_encoder_model
+    return_feature_maps: True
     streams:
       inputs: images
-      outputs: image_activations
-    globals:
-      output_size: image_encoder_output_size
+      outputs: feature_maps
 
   ################# PIPE 3: SHARED IMAGE SIZE ENCODER #################
 
@@ -277,24 +278,27 @@ pipeline:
       prediction_size: image_size_encoder_output_size
 
   ################# PIPE 4: image-question fusion  #################
-  # Element wise multiplication + FF.
+  # Attention + FF.
   question_image_fusion:
     priority: 4.1
     type: *question_image_fusion_type
     dropout_rate: 0.5
+    # Attention params.
+    latent_size: 100
+    num_attention_heads: 2
     streams:
-      image_encodings: image_activations
+      image_encodings: feature_maps
       question_encodings: question_activations
       outputs: fused_activations
     globals:
-      image_encoding_size: image_encoder_output_size
       question_encoding_size: question_encoder_output_size
       output_size: fused_activation_size
+
 
   question_image_ffn:
     priority: 4.2
     type: FeedForwardNetwork 
-    hidden_sizes: [*question_image_fusion_size_val]
+    #hidden_sizes: [*question_image_fusion_size_val]
     dropout_rate: 0.5
     use_logsoftmax: False
     streams:
@@ -313,7 +317,7 @@ pipeline:
     input_streams: [question_image_activations,image_size_activations]
     # Concatenation 
     dim: 1 # default
-    input_dims: [[-1,*question_image_fusion_size_val],[-1,*image_size_encoder_output_size_val]]
+    input_dims: [[-1,1124],[-1,*image_size_encoder_output_size_val]]
     output_dims: [-1,*question_image_size_fusion_size_val]
     streams:
       outputs: concatenated_activations

--- a/configs/vqa_med_2019/evaluation/tom/glove_lstm_resnet152_att_is_cat_ffn_c123_loss.yml
+++ b/configs/vqa_med_2019/evaluation/tom/glove_lstm_resnet152_att_is_cat_ffn_c123_loss.yml
@@ -42,7 +42,7 @@ hyperparameters:
 
   batch_size: &batch_size 256
   preload_images: &preload_images True
-  num_workers: &num_workers 0
+  num_workers: &num_workers 1
 
 # Training parameters:
 training:

--- a/configs/vqa_med_2019/evaluation/tom/glove_lstm_resnet152_mcb_is_cat_ffn_c123_loss.yml
+++ b/configs/vqa_med_2019/evaluation/tom/glove_lstm_resnet152_mcb_is_cat_ffn_c123_loss.yml
@@ -13,7 +13,7 @@ hyperparameters:
   # none | random_affine | random_horizontal_flip | normalize | all
 
   # Image encoder.
-  image_encoder_model: &image_encoder_model resnet50
+  image_encoder_model: &image_encoder_model resnet152
   # Options: vgg16 | densenet121 | resnet152 | resnet50
   image_encoder_output_size_val: &image_encoder_output_size_val 100
   
@@ -25,8 +25,8 @@ hyperparameters:
   question_encoder_output_size_val: &question_encoder_output_size_val 100
   
   # Fusion I: image + question
-  question_image_fusion_type_val: &question_image_fusion_type ElementWiseMultiplication
-  # Options: ElementWiseMultiplication | ? (component: question_image_fusion)
+  question_image_fusion_type_val: &question_image_fusion_type MultimodalCompactBilinearPooling
+  # Options: ElementWiseMultiplication | MultimodalCompactBilinearPooling | VQA_Attention
   question_image_fusion_size_val: &question_image_fusion_size_val 100
 
   # Image size encoder.
@@ -38,9 +38,9 @@ hyperparameters:
   # Final classifier: FFN.
   answer_classifier_hidden_sizes_val: &answer_classifier_hidden_sizes_val [100]
 
-  batch_size: &batch_size 64
-  preload_images: &preload_images True
-  num_workers: &num_workers 0
+  batch_size: &batch_size 150
+  preload_images: &preload_images False
+  num_workers: &num_workers 3
 
 # Training parameters:
 training:

--- a/configs/vqa_med_2019/evaluation/tom/glove_lstm_vgg16_att_is_cat_ffn_c123_loss.yml
+++ b/configs/vqa_med_2019/evaluation/tom/glove_lstm_vgg16_att_is_cat_ffn_c123_loss.yml
@@ -13,32 +13,34 @@ hyperparameters:
   # none | random_affine | random_horizontal_flip | normalize | all
 
   # Image encoder.
-  image_encoder_model: &image_encoder_model resnet50
+  image_encoder_model: &image_encoder_model vgg16
   # Options: vgg16 | densenet121 | resnet152 | resnet50
-  image_encoder_output_size_val: &image_encoder_output_size_val 74
+  #image_encoder_output_size_val: &image_encoder_output_size_val 100
+  # INFO: this variable is not important, as we are using features in this pipeline!!
   
   # Question encoder.
-  question_encoder_embeddings: &question_encoder_embeddings mimic.fastText.no_clean.300d.pickled
+  question_encoder_embeddings: &question_encoder_embeddings glove.6B.50d.txt
   # Options: '' | glove.6B.50d.txt | glove.6B.100d.txt | glove.6B.200d.txt | glove.6B.300d.txt | glove.42B.300d.txt | glove.840B.300d.txt | glove.twitter.27B.txt | mimic.fastText.no_clean.300d.pickled
-  question_encoder_embeddings_size_val: &question_encoder_embeddings_size_val 300
-  question_encoder_lstm_size_val: &question_encoder_lstm_size_val 101
-  question_encoder_output_size_val: &question_encoder_output_size_val 103
+  question_encoder_embeddings_size_val: &question_encoder_embeddings_size_val 50
+  question_encoder_lstm_size_val: &question_encoder_lstm_size_val 50
+  question_encoder_output_size_val: &question_encoder_output_size_val 100
   
   # Fusion I: image + question
-  question_image_fusion_type_val: &question_image_fusion_type ElementWiseMultiplication
-  # Options: ElementWiseMultiplication | ? (component: question_image_fusion)
-  question_image_fusion_size_val: &question_image_fusion_size_val 115
+  question_image_fusion_type_val: &question_image_fusion_type VQA_Attention
+  # Options: ElementWiseMultiplication | VQA_Attention
+  #question_image_fusion_size_val: &question_image_fusion_size_val 1124
+  # INFO: this variable is set by VQA_Attention component!
 
   # Image size encoder.
-  image_size_encoder_output_size_val: &image_size_encoder_output_size_val 11
+  image_size_encoder_output_size_val: &image_size_encoder_output_size_val 10
 
   # Fusion II: (image + question) + image size (must be = question_image_fusion_size_val + image_size_encoder_output_size_val)
-  question_image_size_fusion_size_val: &question_image_size_fusion_size_val 126
+  question_image_size_fusion_size_val: &question_image_size_fusion_size_val 1134
 
   # Final classifier: FFN.
-  answer_classifier_hidden_sizes_val: &answer_classifier_hidden_sizes_val [83]
+  answer_classifier_hidden_sizes_val: &answer_classifier_hidden_sizes_val [500]
 
-  batch_size: &batch_size 200
+  batch_size: &batch_size 100
   preload_images: &preload_images True
   num_workers: &num_workers 0
 
@@ -102,8 +104,8 @@ pipeline:
     priority: 0
     type: GlobalVariablePublisher
     # Add input_size to globals.
-    keys: [question_encoder_output_size, image_size_encoder_input_size, image_size_encoder_output_size, image_encoder_output_size, fused_activation_size]
-    values: [*question_encoder_output_size_val, 2, *image_size_encoder_output_size_val, *image_encoder_output_size_val, *question_image_fusion_size_val]
+    keys: [question_encoder_output_size, image_size_encoder_input_size, image_size_encoder_output_size] #, image_encoder_output_size] #, fused_activation_size]
+    values: [*question_encoder_output_size_val, 2, *image_size_encoder_output_size_val] #, *image_encoder_output_size_val] #, *question_image_fusion_size_val]
 
   # Statistics.
   batch_size:
@@ -256,11 +258,10 @@ pipeline:
     priority: 2.1
     type: TorchVisionWrapper
     model: *image_encoder_model
+    return_feature_maps: True
     streams:
       inputs: images
-      outputs: image_activations
-    globals:
-      output_size: image_encoder_output_size
+      outputs: feature_maps
 
   ################# PIPE 3: SHARED IMAGE SIZE ENCODER #################
 
@@ -277,24 +278,27 @@ pipeline:
       prediction_size: image_size_encoder_output_size
 
   ################# PIPE 4: image-question fusion  #################
-  # Element wise multiplication + FF.
+  # Attention + FF.
   question_image_fusion:
     priority: 4.1
     type: *question_image_fusion_type
     dropout_rate: 0.5
+    # Attention params.
+    latent_size: 100
+    num_attention_heads: 2
     streams:
-      image_encodings: image_activations
+      image_encodings: feature_maps
       question_encodings: question_activations
       outputs: fused_activations
     globals:
-      image_encoding_size: image_encoder_output_size
       question_encoding_size: question_encoder_output_size
       output_size: fused_activation_size
+
 
   question_image_ffn:
     priority: 4.2
     type: FeedForwardNetwork 
-    hidden_sizes: [*question_image_fusion_size_val]
+    #hidden_sizes: [*question_image_fusion_size_val]
     dropout_rate: 0.5
     use_logsoftmax: False
     streams:
@@ -313,7 +317,7 @@ pipeline:
     input_streams: [question_image_activations,image_size_activations]
     # Concatenation 
     dim: 1 # default
-    input_dims: [[-1,*question_image_fusion_size_val],[-1,*image_size_encoder_output_size_val]]
+    input_dims: [[-1,1124],[-1,*image_size_encoder_output_size_val]]
     output_dims: [-1,*question_image_size_fusion_size_val]
     streams:
       outputs: concatenated_activations

--- a/configs/vqa_med_2019/evaluation/tom/glove_lstm_vgg16_att_is_cat_ffn_c123_loss.yml
+++ b/configs/vqa_med_2019/evaluation/tom/glove_lstm_vgg16_att_is_cat_ffn_c123_loss.yml
@@ -42,7 +42,7 @@ hyperparameters:
 
   batch_size: &batch_size 100
   preload_images: &preload_images True
-  num_workers: &num_workers 0
+  num_workers: &num_workers 1
 
 # Training parameters:
 training:

--- a/configs/vqa_med_2019/evaluation/tom/glove_lstm_vgg16_ewm_is_cat_ffn_c123_loss.yml
+++ b/configs/vqa_med_2019/evaluation/tom/glove_lstm_vgg16_ewm_is_cat_ffn_c123_loss.yml
@@ -40,7 +40,7 @@ hyperparameters:
 
   batch_size: &batch_size 100
   preload_images: &preload_images True
-  num_workers: &num_workers 0
+  num_workers: &num_workers 1
 
 # Training parameters:
 training:

--- a/configs/vqa_med_2019/evaluation/tom/glove_lstm_vgg16_ewm_is_cat_ffn_c123_loss.yml
+++ b/configs/vqa_med_2019/evaluation/tom/glove_lstm_vgg16_ewm_is_cat_ffn_c123_loss.yml
@@ -13,32 +13,32 @@ hyperparameters:
   # none | random_affine | random_horizontal_flip | normalize | all
 
   # Image encoder.
-  image_encoder_model: &image_encoder_model resnet50
+  image_encoder_model: &image_encoder_model vgg16
   # Options: vgg16 | densenet121 | resnet152 | resnet50
-  image_encoder_output_size_val: &image_encoder_output_size_val 74
+  image_encoder_output_size_val: &image_encoder_output_size_val 100
   
   # Question encoder.
-  question_encoder_embeddings: &question_encoder_embeddings mimic.fastText.no_clean.300d.pickled
+  question_encoder_embeddings: &question_encoder_embeddings glove.6B.50d.txt
   # Options: '' | glove.6B.50d.txt | glove.6B.100d.txt | glove.6B.200d.txt | glove.6B.300d.txt | glove.42B.300d.txt | glove.840B.300d.txt | glove.twitter.27B.txt | mimic.fastText.no_clean.300d.pickled
-  question_encoder_embeddings_size_val: &question_encoder_embeddings_size_val 300
-  question_encoder_lstm_size_val: &question_encoder_lstm_size_val 101
-  question_encoder_output_size_val: &question_encoder_output_size_val 103
+  question_encoder_embeddings_size_val: &question_encoder_embeddings_size_val 50
+  question_encoder_lstm_size_val: &question_encoder_lstm_size_val 50
+  question_encoder_output_size_val: &question_encoder_output_size_val 100
   
   # Fusion I: image + question
   question_image_fusion_type_val: &question_image_fusion_type ElementWiseMultiplication
   # Options: ElementWiseMultiplication | ? (component: question_image_fusion)
-  question_image_fusion_size_val: &question_image_fusion_size_val 115
+  question_image_fusion_size_val: &question_image_fusion_size_val 100
 
   # Image size encoder.
-  image_size_encoder_output_size_val: &image_size_encoder_output_size_val 11
+  image_size_encoder_output_size_val: &image_size_encoder_output_size_val 10
 
   # Fusion II: (image + question) + image size (must be = question_image_fusion_size_val + image_size_encoder_output_size_val)
-  question_image_size_fusion_size_val: &question_image_size_fusion_size_val 126
+  question_image_size_fusion_size_val: &question_image_size_fusion_size_val 110
 
   # Final classifier: FFN.
-  answer_classifier_hidden_sizes_val: &answer_classifier_hidden_sizes_val [83]
+  answer_classifier_hidden_sizes_val: &answer_classifier_hidden_sizes_val [100]
 
-  batch_size: &batch_size 200
+  batch_size: &batch_size 100
   preload_images: &preload_images True
   num_workers: &num_workers 0
 

--- a/configs/vqa_med_2019/evaluation/tom/glove_lstm_vgg16_mcb_is_cat_ffn_c123_loss.yml
+++ b/configs/vqa_med_2019/evaluation/tom/glove_lstm_vgg16_mcb_is_cat_ffn_c123_loss.yml
@@ -13,32 +13,32 @@ hyperparameters:
   # none | random_affine | random_horizontal_flip | normalize | all
 
   # Image encoder.
-  image_encoder_model: &image_encoder_model resnet50
+  image_encoder_model: &image_encoder_model vgg16
   # Options: vgg16 | densenet121 | resnet152 | resnet50
-  image_encoder_output_size_val: &image_encoder_output_size_val 74
+  image_encoder_output_size_val: &image_encoder_output_size_val 100
   
   # Question encoder.
-  question_encoder_embeddings: &question_encoder_embeddings mimic.fastText.no_clean.300d.pickled
+  question_encoder_embeddings: &question_encoder_embeddings glove.6B.50d.txt
   # Options: '' | glove.6B.50d.txt | glove.6B.100d.txt | glove.6B.200d.txt | glove.6B.300d.txt | glove.42B.300d.txt | glove.840B.300d.txt | glove.twitter.27B.txt | mimic.fastText.no_clean.300d.pickled
-  question_encoder_embeddings_size_val: &question_encoder_embeddings_size_val 300
-  question_encoder_lstm_size_val: &question_encoder_lstm_size_val 101
-  question_encoder_output_size_val: &question_encoder_output_size_val 103
+  question_encoder_embeddings_size_val: &question_encoder_embeddings_size_val 50
+  question_encoder_lstm_size_val: &question_encoder_lstm_size_val 50
+  question_encoder_output_size_val: &question_encoder_output_size_val 100
   
   # Fusion I: image + question
-  question_image_fusion_type_val: &question_image_fusion_type ElementWiseMultiplication
-  # Options: ElementWiseMultiplication | ? (component: question_image_fusion)
-  question_image_fusion_size_val: &question_image_fusion_size_val 115
+  question_image_fusion_type_val: &question_image_fusion_type MultimodalCompactBilinearPooling
+  # Options: ElementWiseMultiplication | MultimodalCompactBilinearPooling | 
+  question_image_fusion_size_val: &question_image_fusion_size_val 100
 
   # Image size encoder.
-  image_size_encoder_output_size_val: &image_size_encoder_output_size_val 11
+  image_size_encoder_output_size_val: &image_size_encoder_output_size_val 10
 
   # Fusion II: (image + question) + image size (must be = question_image_fusion_size_val + image_size_encoder_output_size_val)
-  question_image_size_fusion_size_val: &question_image_size_fusion_size_val 126
+  question_image_size_fusion_size_val: &question_image_size_fusion_size_val 110
 
   # Final classifier: FFN.
-  answer_classifier_hidden_sizes_val: &answer_classifier_hidden_sizes_val [83]
+  answer_classifier_hidden_sizes_val: &answer_classifier_hidden_sizes_val [100]
 
-  batch_size: &batch_size 200
+  batch_size: &batch_size 100
   preload_images: &preload_images True
   num_workers: &num_workers 0
 

--- a/configs/vqa_med_2019/evaluation/tom/glove_lstm_vgg16_mcb_is_cat_ffn_c123_loss.yml
+++ b/configs/vqa_med_2019/evaluation/tom/glove_lstm_vgg16_mcb_is_cat_ffn_c123_loss.yml
@@ -15,7 +15,7 @@ hyperparameters:
   # Image encoder.
   image_encoder_model: &image_encoder_model vgg16
   # Options: vgg16 | densenet121 | resnet152 | resnet50
-  image_encoder_output_size_val: &image_encoder_output_size_val 100
+  image_encoder_output_size_val: &image_encoder_output_size_val 1000
   
   # Question encoder.
   question_encoder_embeddings: &question_encoder_embeddings glove.6B.50d.txt
@@ -27,20 +27,20 @@ hyperparameters:
   # Fusion I: image + question
   question_image_fusion_type_val: &question_image_fusion_type MultimodalCompactBilinearPooling
   # Options: ElementWiseMultiplication | MultimodalCompactBilinearPooling | 
-  question_image_fusion_size_val: &question_image_fusion_size_val 100
+  question_image_fusion_size_val: &question_image_fusion_size_val 200
 
   # Image size encoder.
   image_size_encoder_output_size_val: &image_size_encoder_output_size_val 10
 
   # Fusion II: (image + question) + image size (must be = question_image_fusion_size_val + image_size_encoder_output_size_val)
-  question_image_size_fusion_size_val: &question_image_size_fusion_size_val 110
+  question_image_size_fusion_size_val: &question_image_size_fusion_size_val 210
 
   # Final classifier: FFN.
-  answer_classifier_hidden_sizes_val: &answer_classifier_hidden_sizes_val [100]
+  answer_classifier_hidden_sizes_val: &answer_classifier_hidden_sizes_val [500]
 
-  batch_size: &batch_size 100
+  batch_size: &batch_size 200
   preload_images: &preload_images True
-  num_workers: &num_workers 0
+  num_workers: &num_workers 1
 
 # Training parameters:
 training:

--- a/configs/vqa_med_2019/extend_answers_c4.yml
+++ b/configs/vqa_med_2019/extend_answers_c4.yml
@@ -6,7 +6,7 @@ training_answers:
     type: &p_type VQAMED2019
     data_folder: &data_folder ~/data/vqa-med
     split: training
-    categories: all
+    categories: C4
     resize_image: &resize_image [224, 224]
     batch_size: 64
     # Appy all preprocessing/data augmentations.
@@ -24,7 +24,7 @@ validation_answers:
     type: *p_type
     data_folder: *data_folder
     split: validation
-    categories: all
+    categories: C4
     resize_image: *resize_image     
     batch_size: 64
     # Appy all preprocessing/data augmentations.
@@ -37,24 +37,6 @@ validation_answers:
     # Use 1 worker, so batches will follow the samples order.
     num_workers: 1
 
-
-# Testing parameters:
-test_answers:
-  problem:
-    type: *p_type 
-    data_folder: *data_folder
-    split: test
-    resize_image: *resize_image     
-    batch_size: 64
-    # Appy all preprocessing/data augmentations.
-    question_preprocessing: lowercase,remove_punctuation,tokenize
-    streams: 
-      questions: tokenized_questions
-  dataloader:
-    # No sampler, process samples in the same order.
-    shuffle: false
-    # Use 1 worker, so batches will follow the samples order.
-    num_workers: 1
 
 # Add component for exporting answers to files.
 pipeline:

--- a/configs/vqa_med_2019/question_categorization/default_question_categorization.yml
+++ b/configs/vqa_med_2019/question_categorization/default_question_categorization.yml
@@ -5,6 +5,9 @@ training:
   problem:
     categories: all
     export_sample_weights: ~/data/vqa-med/answers.all.weights.csv
+    # Do not load and stream images!
+    stream_images: False
+    batch_size:  256
   sampler:
     weights: ~/data/vqa-med/answers.all.weights.csv
   terminal_conditions:
@@ -13,6 +16,9 @@ training:
 validation:
   problem:
     categories: all
+    # Do not load and stream images!
+    stream_images: False
+    batch_size:  256
 
 
 pipeline:

--- a/ptp/components/models/vqa/attention.py
+++ b/ptp/components/models/vqa/attention.py
@@ -62,6 +62,8 @@ class VQA_Attention(Model):
 
         # Output feature size
         self.output_size = self.feature_maps_depth*self.num_attention_heads + self.question_encoding_size
+        # Export to globals.
+        self.globals["output_size"] = self.output_size
 
         # Map image and question encodings to a common latent space of dimension 'latent_size'.
         self.image_encodings_conv = torch.nn.Conv2d(self.feature_maps_depth, self.latent_size, 1, bias=False)

--- a/ptp/components/transforms/__init__.py
+++ b/ptp/components/transforms/__init__.py
@@ -1,10 +1,12 @@
 from .concatenation import Concatenation
 from .list_to_tensor import ListToTensor
+from .reduce_tensor import ReduceTensor
 from .reshape_tensor import ReshapeTensor
 
 
 __all__ = [
     'Concatenation',
     'ListToTensor',
+    'ReduceTensor',
     'ReshapeTensor',
     ]

--- a/setup.py
+++ b/setup.py
@@ -166,9 +166,9 @@ setup(
         'nltk',
         'pandas',
         'pillow',
-        #'torchtext',
-        'torchvision',
-        'torch',
+        'torchtext==0.3.1',
+        'torchvision==0.1.9',
+        'torch==1.0.1',
         'PyYAML',
         'requests'
         ],

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ setup(
         'pandas',
         'pillow',
         'torchtext==0.3.1',
-        'torchvision==0.1.9',
+        'torchvision==0.2.1',
         'torch==1.0.1',
         'PyYAML',
         'requests'


### PR DESCRIPTION
***IMPORTANT:***
  * config.py: **set required versions of PTP: pytorch (1.0.1) torchvision (0.2.1), tochtext (0.3.1)**

New features:
  * new component: ReduceTensor
  * progress bar added to load embeddings

New configs:
  * for experiments with answer-word classifiers
  * for evaluation of C123 pipelines

Fixes:
  * fix in loading embeddings when label has many words
  * fix in MCB: projection matrices are saved/loaded with the model (!), added option so they can also be trainable (they won't be doing "sketching" anymore though)
  * fix in VQA_Attention: exporting calculated output_size to globals