### PR TITLE
bug fix in concatenation for Fusion mode

### DIFF
--- a/ptp/components/models/vqa/attention.py
+++ b/ptp/components/models/vqa/attention.py
@@ -151,7 +151,7 @@ class VQA_Attention(Model):
             outputs = attention_enc_img
         elif(self.output_mode == 'Fusion'):
             # Fusion -- Concatenate attention-weighted image encodings and question encodings.
-            outputs = torch.cat([attention_enc_img, latent_q], dim=1)
+            outputs = torch.cat([attention_enc_img, enc_q], dim=1)
         # print("outputs", outputs.shape)
         # Add predictions to datadict.
         data_dict.extend({self.key_outputs: outputs})


### PR DESCRIPTION
The encoded question must be concatenated with attention-weighted image for 'Fusion' mode... instead, the linear projected question was being concatenated.

Thus far, since the latent_size for VQA and question encoding size were set to 100 in most of Tom's experiments, this bug went unnoticed! :-/